### PR TITLE
endpoint was changed to get rid from domain name path

### DIFF
--- a/kafka-ui-react-app/package.json
+++ b/kafka-ui-react-app/package.json
@@ -90,7 +90,8 @@
     "node-sass": "^4.13.1",
     "prettier": "^2.0.4",
     "react-scripts": "3.4.0",
-    "typescript": "~3.7.4"
+    "typescript": "~3.7.4",
+    "dotenv": "^8.2.0"
   },
   "proxy": "http://localhost:8080"
 }


### PR DESCRIPTION
This is needed because otherwise UI trying to construct full URI during build process, and we cannot use the same docker image for production and local deployments, if we just mentioned relative path, the same image can work for any deployments/domain names.