### PR TITLE
Update Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,6 +70,9 @@ spec:
             }
         }
         stage('Remove SNAPSHOT from version') {
+            when {
+                expression { return env.GIT_BRANCH ==~ /.*master$/; }
+            }
             steps {
                 container('docker-client') {
                     sh "docker run -v $WORKSPACE:/usr/src/mymaven -v /tmp/repository:/root/.m2/repository -w /usr/src/mymaven maven:3.6.3-jdk-13 bash -c 'mvn versions:set -DremoveSnapshot'"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -88,6 +88,12 @@ spec:
             }
         }
         stage('Build artifact') {
+            when {
+                anyOf {
+                    changeRequest ()
+                    expression { return env.GIT_BRANCH ==~ /.*master$/; }
+                }
+            }
             steps {
                 container('docker-client') {
                     sh "docker run -v /var/run/docker.sock:/var/run/docker.sock -v $WORKSPACE:/usr/src/mymaven -v /tmp/repository:/root/.m2/repository -w /usr/src/mymaven provectuslabs/openjdk:13 bash -c 'chown -R \$(whoami):\$(whoami) kafka-ui-react-app && ./mvnw clean package -Pprod'"
@@ -96,7 +102,7 @@ spec:
         }
         stage('Build docker image') {
             when {
-                expression { return env.GIT_BRANCH == 'master'; }
+                expression { return env.GIT_BRANCH ==~ /.*master$/; }
             }
             steps {
                 container('docker-client') {
@@ -110,7 +116,7 @@ spec:
         }
         stage('Publish docker image') {
             when {
-                expression { return env.GIT_BRANCH == 'master'; }
+                expression { return env.GIT_BRANCH ==~ /.*master$/; }
             }
             steps {
                 container('docker-client') {
@@ -125,7 +131,7 @@ spec:
         }
         stage('Remove unused docker image') {
             when {
-                expression { return env.GIT_BRANCH == 'master'; }
+                expression { return env.GIT_BRANCH ==~ /.*master$/; }
             }
             steps{
                 container('docker-client') {
@@ -135,7 +141,7 @@ spec:
         }
         stage('Create github release with text from commits') {
             when {
-                expression { return env.GIT_BRANCH == 'master'; }
+                expression { return env.GIT_BRANCH ==~ /.*master$/; }
             }
             steps {
                 script {
@@ -150,7 +156,7 @@ spec:
         }
         stage('Checkout master') {
             when {
-                expression { return env.GIT_BRANCH == 'master'; }
+                expression { return env.GIT_BRANCH ==~ /.*master$/; }
             }
             steps {
                 sh 'git checkout master'
@@ -158,7 +164,7 @@ spec:
         }
         stage('Increase version in master') {
             when {
-                expression { return env.GIT_BRANCH == 'master'; }
+                expression { return env.GIT_BRANCH ==~ /.*master$/; }
             }
             steps {
                 container('docker-client') {
@@ -168,7 +174,7 @@ spec:
         }
         stage('Push to master') {
             when {
-                expression { return env.GIT_BRANCH == 'master'; }
+                expression { return env.GIT_BRANCH ==~ /.*master$/; }
             }
             steps {
                 script {


### PR DESCRIPTION
`== 'master'` replaced with `==~ /.*master$/`
The reason, Rustam did this modification from `origin/master` i suppose he was not aware that there is separate job for build/release, and jobs under "Provectus" git project is used only for CI's without release.

Also added login to prevent building for each branches without PRs