### PR TITLE
MINOR: Add line-continuation to shell command

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ The official Docker image for Kafka UI is hosted here: [hub.docker.com/r/provect
 Launch Docker container in the background:
 ```sh
 
-docker run -p 8080:8080
-	-e KAFKA_CLUSTERS_0_NAME=local
-	-e KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS=kafka:9092
+docker run -p 8080:8080 \
+	-e KAFKA_CLUSTERS_0_NAME=local \
+	-e KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS=kafka:9092 \
 	-d provectuslabs/kafka-ui:latest 
 
 ```


### PR DESCRIPTION
The command will fail with `zsh: command not found: -e` without line-continuation