### PR TITLE
Testcontainers speedup and stabilization

### DIFF
--- a/kafka-ui-api/src/test/java/com/provectus/kafka/ui/AbstractBaseTest.java
+++ b/kafka-ui-api/src/test/java/com/provectus/kafka/ui/AbstractBaseTest.java
@@ -9,10 +9,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.containers.Network;
-import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
-
-import java.time.Duration;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
@@ -32,10 +29,8 @@ public abstract class AbstractBaseTest {
 
     public static final KafkaConnectContainer kafkaConnect = new KafkaConnectContainer(CONFLUENT_PLATFORM_VERSION)
             .withKafka(kafka)
-            .waitingFor(Wait.forHttp("/"))
             .dependsOn(kafka)
-            .dependsOn(schemaRegistry)
-            .withStartupTimeout(Duration.ofMinutes(15));
+            .dependsOn(schemaRegistry);
 
     static {
         kafka.start();

--- a/kafka-ui-api/src/test/java/com/provectus/kafka/ui/AbstractBaseTest.java
+++ b/kafka-ui-api/src/test/java/com/provectus/kafka/ui/AbstractBaseTest.java
@@ -4,9 +4,7 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContextInitializer;
-import org.springframework.context.ApplicationListener;
 import org.springframework.context.ConfigurableApplicationContext;
-import org.springframework.context.event.ContextClosedEvent;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.testcontainers.containers.KafkaContainer;
@@ -20,41 +18,36 @@ import java.time.Duration;
 @SpringBootTest
 @ActiveProfiles("test")
 public abstract class AbstractBaseTest {
+    private static final String CONFLUENT_PLATFORM_VERSION = "5.2.1";
+
+    public static final KafkaContainer kafka = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka").withTag(CONFLUENT_PLATFORM_VERSION))
+            .withNetwork(Network.SHARED);
+
+    public static final SchemaRegistryContainer schemaRegistry = new SchemaRegistryContainer(CONFLUENT_PLATFORM_VERSION)
+            .withKafka(kafka)
+            .dependsOn(kafka);
+
+    public static final KafkaConnectContainer kafkaConnect = new KafkaConnectContainer(CONFLUENT_PLATFORM_VERSION)
+            .withKafka(kafka)
+            .waitingFor(Wait.forHttp("/"))
+            .dependsOn(kafka)
+            .dependsOn(schemaRegistry)
+            .withStartupTimeout(Duration.ofMinutes(15));
+
+    static {
+        kafka.start();
+        schemaRegistry.start();
+        kafkaConnect.start();
+    }
 
     public static class Initializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
-        public final KafkaContainer kafka = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:5.2.1"))
-                .withNetwork(Network.SHARED);
-
-        public final SchemaRegistryContainer schemaRegistry = new SchemaRegistryContainer("5.2.1")
-                .withKafka(kafka)
-                .dependsOn(kafka);
-
-        public final KafkaConnectContainer kafkaConnect = new KafkaConnectContainer("5.2.1")
-                .withKafka(kafka)
-                .waitingFor(
-                        Wait.forLogMessage(".*Finished starting connectors and tasks.*", 1)
-                )
-                .dependsOn(kafka)
-                .dependsOn(schemaRegistry)
-                .withStartupTimeout(Duration.ofMinutes(15));
-
         @Override
         public void initialize(@NotNull ConfigurableApplicationContext context) {
-            kafka.start();
-            schemaRegistry.start();
-            kafkaConnect.start();
-
             System.setProperty("kafka.clusters.0.name", "local");
             System.setProperty("kafka.clusters.0.bootstrapServers", kafka.getBootstrapServers());
             System.setProperty("kafka.clusters.0.schemaRegistry", schemaRegistry.getTarget());
             System.setProperty("kafka.clusters.0.kafkaConnect.0.name", "kafka-connect");
             System.setProperty("kafka.clusters.0.kafkaConnect.0.address", kafkaConnect.getTarget());
-
-            context.addApplicationListener((ApplicationListener<ContextClosedEvent>) event -> {
-                kafkaConnect.close();
-                schemaRegistry.close();
-                kafka.close();
-            });
         }
     }
 }

--- a/kafka-ui-api/src/test/java/com/provectus/kafka/ui/KafkaConnectContainer.java
+++ b/kafka-ui-api/src/test/java/com/provectus/kafka/ui/KafkaConnectContainer.java
@@ -14,7 +14,7 @@ public class KafkaConnectContainer extends GenericContainer<KafkaConnectContaine
         super("confluentinc/cp-kafka-connect:" + version);
         addExposedPort(CONNECT_PORT);
         waitStrategy = Wait.forHttp("/")
-                .withStartupTimeout(Duration.ofMinutes(10));
+                .withStartupTimeout(Duration.ofMinutes(5));
     }
 
 

--- a/kafka-ui-api/src/test/java/com/provectus/kafka/ui/KafkaConnectContainer.java
+++ b/kafka-ui-api/src/test/java/com/provectus/kafka/ui/KafkaConnectContainer.java
@@ -9,6 +9,7 @@ public class KafkaConnectContainer extends GenericContainer<KafkaConnectContaine
 
     public KafkaConnectContainer(String version) {
         super("confluentinc/cp-kafka-connect:" + version);
+        addExposedPort(CONNECT_PORT);
     }
 
 

--- a/kafka-ui-api/src/test/java/com/provectus/kafka/ui/KafkaConnectContainer.java
+++ b/kafka-ui-api/src/test/java/com/provectus/kafka/ui/KafkaConnectContainer.java
@@ -3,6 +3,9 @@ package com.provectus.kafka.ui;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.containers.Network;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+import java.time.Duration;
 
 public class KafkaConnectContainer extends GenericContainer<KafkaConnectContainer> {
     private static final int CONNECT_PORT = 8083;
@@ -10,6 +13,8 @@ public class KafkaConnectContainer extends GenericContainer<KafkaConnectContaine
     public KafkaConnectContainer(String version) {
         super("confluentinc/cp-kafka-connect:" + version);
         addExposedPort(CONNECT_PORT);
+        waitStrategy = Wait.forHttp("/")
+                .withStartupTimeout(Duration.ofMinutes(10));
     }
 
 


### PR DESCRIPTION
Moved testcontainers lifecycle control back to singleton.
Right now we are creating new container for every test and it's too much IMO, with singleton containers we both reduce overall build/test time and reduce possible error counts during the build, considering every container start is error prone.

Сhanged kafka connect container wait strategy from log pattern to http request - waiting for log times out from time to time.