### PR TITLE
added features field to kafka cluster

### DIFF
--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/mapper/ClusterMapper.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/mapper/ClusterMapper.java
@@ -37,6 +37,7 @@ public interface ClusterMapper {
     TopicConfig toTopicConfig(InternalTopicConfig topic);
     Replica toReplica(InternalReplica replica);
     Connect toKafkaConnect(KafkaConnectCluster connect);
+    List<Cluster.FeaturesEnum> toFeaturesEnum(List<Feature> features);
 
     @Mapping(target = "isCompatible", source = "compatible")
     CompatibilityCheckResponse toCompatibilityCheckResponse(InternalCompatibilityCheck dto);

--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/model/Feature.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/model/Feature.java
@@ -1,0 +1,27 @@
+package com.provectus.kafka.ui.model;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+public enum Feature {
+    KAFKA_CONNECT(cluster -> Optional.ofNullable(cluster.getKafkaConnect())
+            .filter(Predicate.not(List::isEmpty))
+            .isPresent()
+    ),
+    SCHEMA_REGISTRY(cluster -> cluster.getSchemaRegistry() != null);
+
+    private final Predicate<KafkaCluster> isEnabled;
+
+    Feature(Predicate<KafkaCluster> isEnabled) {
+        this.isEnabled = isEnabled;
+    }
+
+    public static List<Feature> getEnabledFeatures(KafkaCluster cluster) {
+        return Arrays.stream(values())
+                .filter(feature -> feature.isEnabled.test(cluster))
+                .collect(Collectors.toList());
+    }
+}

--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/model/KafkaCluster.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/model/KafkaCluster.java
@@ -28,4 +28,5 @@ public class KafkaCluster {
     private final String protobufMessageName;
     private final Properties properties;
     private final Boolean readOnly;
+    private final List<Feature> features;
 }

--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/service/ClustersStorage.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/service/ClustersStorage.java
@@ -2,6 +2,7 @@ package com.provectus.kafka.ui.service;
 
 import com.provectus.kafka.ui.config.ClustersProperties;
 import com.provectus.kafka.ui.mapper.ClusterMapper;
+import com.provectus.kafka.ui.model.Feature;
 import com.provectus.kafka.ui.model.KafkaCluster;
 import lombok.RequiredArgsConstructor;
 import org.mapstruct.factory.Mappers;
@@ -29,7 +30,13 @@ public class ClustersStorage {
             if (kafkaClusters.get(clusterProperties.getName()) != null) {
                 throw new IllegalStateException("Application config isn't correct. Two clusters can't have the same name");
             }
-            kafkaClusters.put(clusterProperties.getName(), clusterMapper.toKafkaCluster(clusterProperties));
+            KafkaCluster cluster = clusterMapper.toKafkaCluster(clusterProperties);
+            kafkaClusters.put(
+                    clusterProperties.getName(),
+                    cluster.toBuilder()
+                            .features(Feature.getEnabledFeatures(cluster))
+                            .build()
+            );
         }
     }
 

--- a/kafka-ui-contract/src/main/resources/swagger/kafka-ui-api.yaml
+++ b/kafka-ui-contract/src/main/resources/swagger/kafka-ui-api.yaml
@@ -1079,6 +1079,13 @@ components:
           type: number
         readOnly:
           type: boolean
+        features:
+          type: array
+          items:
+            type: string
+            enum:
+              - SCHEMA_REGISTRY
+              - KAFKA_CONNECT
       required:
         - id
         - name


### PR DESCRIPTION
Example response:
```
[
    {
        "brokerCount": 1,
        "bytesInPerSec": 0,
        "bytesOutPerSec": 0,
        "defaultCluster": null,
        "features": [],
        "name": "secondLocal",
        "onlinePartitionCount": 57,
        "readOnly": false,
        "status": "online",
        "topicCount": 5
    },
    {
        "brokerCount": 2,
        "bytesInPerSec": 0,
        "bytesOutPerSec": 0,
        "defaultCluster": null,
        "features": [
            "KAFKA_CONNECT",
            "SCHEMA_REGISTRY"
        ],
        "name": "local",
        "onlinePartitionCount": 85,
        "readOnly": false,
        "status": "online",
        "topicCount": 7
    }
]
```