### PR TITLE
update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,12 +66,11 @@ Steps to build Kafka UI locally with Docker:
 1. Install Homebrew Cask:
 ```sh
 > brew update
-> brew cask
 ``` 
 2. Install JAVA 13 with Homebrew Cask:
 ```sh
-> brew tap homebrew/cask-versions
-> brew cask install java (or java13 if 13th version is not the latest one)
+> brew tap adoptopenjdk/openjdk
+> brew install adoptopenjdk13
 ``` 
 ### Building
 


### PR DESCRIPTION
The current README file doesn't provide valid instructions for the latest `brew` version. This PR contains changes that work for brew version 3.0.8