### PR TITLE
add nodePort support

### DIFF
--- a/charts/kafka-ui/templates/service.yaml
+++ b/charts/kafka-ui/templates/service.yaml
@@ -11,5 +11,8 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+      {{- if (and (eq .Values.service.type "NodePort") .Values.service.nodePort) }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
   selector:
     {{- include "kafka-ui.selectorLabels" . | nindent 4 }}

--- a/charts/kafka-ui/values.yaml
+++ b/charts/kafka-ui/values.yaml
@@ -41,6 +41,8 @@ securityContext: {}
 service:
   type: ClusterIP
   port: 80
+  # if you want to force a specific nodePort. Must be use with service.type=NodePort
+  # nodePort:
 
 ingress:
   enabled: false


### PR DESCRIPTION
to deploy kafka-ui with nodePort add those commands when you install/update the chart

--set service.type=NodePort --set service.nodePort=31000