### PR TITLE
#121 Topic level consumer groups & consumer group details

### DIFF
--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/controller/ConsumerGroupsController.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/controller/ConsumerGroupsController.java
@@ -3,6 +3,7 @@ package com.provectus.kafka.ui.controller;
 import com.provectus.kafka.ui.api.ConsumerGroupsApi;
 import com.provectus.kafka.ui.model.ConsumerGroup;
 import com.provectus.kafka.ui.model.ConsumerGroupDetails;
+import com.provectus.kafka.ui.model.TopicConsumerGroups;
 import com.provectus.kafka.ui.service.ClusterService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -33,5 +34,12 @@ public class ConsumerGroupsController implements ConsumerGroupsApi {
         .map(Flux::fromIterable)
         .map(ResponseEntity::ok)
         .switchIfEmpty(Mono.just(ResponseEntity.notFound().build()));
+  }
+
+  @Override
+  public Mono<ResponseEntity<TopicConsumerGroups>> getTopicConsumerGroups(
+      String clusterName, String topicName, ServerWebExchange exchange) {
+    return clusterService.getTopicConsumerGroupDetail(clusterName, topicName)
+        .map(ResponseEntity::ok);
   }
 }

--- a/kafka-ui-contract/src/main/resources/swagger/kafka-ui-api.yaml
+++ b/kafka-ui-contract/src/main/resources/swagger/kafka-ui-api.yaml
@@ -346,6 +346,31 @@ paths:
         404:
           description: Not found
 
+  /api/clusters/{clusterName}/topics/{topicName}/consumergroups:
+    get:
+      tags:
+        - Consumer Groups
+      summary: get Consumer Groups By Topics
+      operationId: getTopicConsumerGroups
+      parameters:
+        - name: clusterName
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: topicName
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TopicConsumerGroups'
+
   /api/clusters/{clusterName}/consumer-groups/{id}:
     get:
       tags:
@@ -1330,6 +1355,14 @@ components:
             type: integer
         numTopics:
             type: integer
+        simple:
+          type: boolean
+        partitionAssignor:
+          type: string
+        state:
+          type: string
+        coordintor:
+          type: string
       required:
         - clusterId
         - consumerGroupId
@@ -1397,6 +1430,8 @@ components:
     ConsumerTopicPartitionDetail:
       type: object
       properties:
+        groupId:
+          type: string
         consumerId:
           type: string
         topic:
@@ -1416,11 +1451,27 @@ components:
           format: int64
       required:
         - consumerId
-        
+
+    TopicConsumerGroups:
+      type: object
+      properties:
+        consumers:
+          type: array
+          items:
+            $ref: '#/components/schemas/ConsumerTopicPartitionDetail'
+
     ConsumerGroupDetails:
       type: object
       properties:
         consumerGroupId:
+          type: string
+        simple:
+         type: boolean
+        partitionAssignor:
+          type: string
+        state:
+          type: string
+        coordintor:
           type: string
         consumers:
           type: array


### PR DESCRIPTION
Added topic level consumer groups members:

```
/api/clusters/{clusterName}/topics/{topicName}/consumergroups
```

And extended consumer groups details with state, simple, assignor