### PR TITLE
[issues-357] - User should not be able to update/delete

### DIFF
--- a/kafka-ui-react-app/src/components/Topics/List/ListItem.tsx
+++ b/kafka-ui-react-app/src/components/Topics/List/ListItem.tsx
@@ -66,8 +66,8 @@ const ListItem: React.FC<ListItemProps> = ({
           {internal ? 'Internal' : 'External'}
         </div>
       </td>
-      <td className="value">
-        {!internal ? (
+      {!internal ? (
+        <td className="value">
           <div className="has-text-right">
             <Dropdown
               label={
@@ -87,15 +87,15 @@ const ListItem: React.FC<ListItemProps> = ({
               </DropdownItem>
             </Dropdown>
           </div>
-        ) : null}
-        <ConfirmationModal
-          isOpen={isDeleteTopicConfirmationVisible}
-          onCancel={() => setDeleteTopicConfirmationVisible(false)}
-          onConfirm={deleteTopicHandler}
-        >
-          Are you sure want to remove <b>{name}</b> topic?
-        </ConfirmationModal>
-      </td>
+          <ConfirmationModal
+            isOpen={isDeleteTopicConfirmationVisible}
+            onCancel={() => setDeleteTopicConfirmationVisible(false)}
+            onConfirm={deleteTopicHandler}
+          >
+            Are you sure want to remove <b>{name}</b> topic?
+          </ConfirmationModal>
+        </td>
+      ) : null}
     </tr>
   );
 };

--- a/kafka-ui-react-app/src/components/Topics/List/ListItem.tsx
+++ b/kafka-ui-react-app/src/components/Topics/List/ListItem.tsx
@@ -66,36 +66,38 @@ const ListItem: React.FC<ListItemProps> = ({
           {internal ? 'Internal' : 'External'}
         </div>
       </td>
-      {!internal ? (
-        <td className="value">
-          <div className="has-text-right">
-            <Dropdown
-              label={
-                <span className="icon">
-                  <i className="fas fa-cog" />
-                </span>
-              }
-              right
-            >
-              <DropdownItem onClick={clearTopicMessagesHandler}>
-                <span className="has-text-danger">Clear Messages</span>
-              </DropdownItem>
-              <DropdownItem
-                onClick={() => setDeleteTopicConfirmationVisible(true)}
+      <td className="topic-action-block">
+        {!internal ? (
+          <>
+            <div className="has-text-right">
+              <Dropdown
+                label={
+                  <span className="icon">
+                    <i className="fas fa-cog" />
+                  </span>
+                }
+                right
               >
-                <span className="has-text-danger">Remove Topic</span>
-              </DropdownItem>
-            </Dropdown>
-          </div>
-          <ConfirmationModal
-            isOpen={isDeleteTopicConfirmationVisible}
-            onCancel={() => setDeleteTopicConfirmationVisible(false)}
-            onConfirm={deleteTopicHandler}
-          >
-            Are you sure want to remove <b>{name}</b> topic?
-          </ConfirmationModal>
-        </td>
-      ) : null}
+                <DropdownItem onClick={clearTopicMessagesHandler}>
+                  <span className="has-text-danger">Clear Messages</span>
+                </DropdownItem>
+                <DropdownItem
+                  onClick={() => setDeleteTopicConfirmationVisible(true)}
+                >
+                  <span className="has-text-danger">Remove Topic</span>
+                </DropdownItem>
+              </Dropdown>
+            </div>
+            <ConfirmationModal
+              isOpen={isDeleteTopicConfirmationVisible}
+              onCancel={() => setDeleteTopicConfirmationVisible(false)}
+              onConfirm={deleteTopicHandler}
+            >
+              Are you sure want to remove <b>{name}</b> topic?
+            </ConfirmationModal>
+          </>
+        ) : null}
+      </td>
     </tr>
   );
 };

--- a/kafka-ui-react-app/src/components/Topics/List/ListItem.tsx
+++ b/kafka-ui-react-app/src/components/Topics/List/ListItem.tsx
@@ -66,26 +66,28 @@ const ListItem: React.FC<ListItemProps> = ({
           {internal ? 'Internal' : 'External'}
         </div>
       </td>
-      <td>
-        <div className="has-text-right">
-          <Dropdown
-            label={
-              <span className="icon">
-                <i className="fas fa-cog" />
-              </span>
-            }
-            right
-          >
-            <DropdownItem onClick={clearTopicMessagesHandler}>
-              <span className="has-text-danger">Clear Messages</span>
-            </DropdownItem>
-            <DropdownItem
-              onClick={() => setDeleteTopicConfirmationVisible(true)}
+      <td className="value">
+        {!internal ? (
+          <div className="has-text-right">
+            <Dropdown
+              label={
+                <span className="icon">
+                  <i className="fas fa-cog" />
+                </span>
+              }
+              right
             >
-              <span className="has-text-danger">Remove Topic</span>
-            </DropdownItem>
-          </Dropdown>
-        </div>
+              <DropdownItem onClick={clearTopicMessagesHandler}>
+                <span className="has-text-danger">Clear Messages</span>
+              </DropdownItem>
+              <DropdownItem
+                onClick={() => setDeleteTopicConfirmationVisible(true)}
+              >
+                <span className="has-text-danger">Remove Topic</span>
+              </DropdownItem>
+            </Dropdown>
+          </div>
+        ) : null}
         <ConfirmationModal
           isOpen={isDeleteTopicConfirmationVisible}
           onCancel={() => setDeleteTopicConfirmationVisible(false)}

--- a/kafka-ui-react-app/src/components/Topics/List/__tests__/ListItem.spec.tsx
+++ b/kafka-ui-react-app/src/components/Topics/List/__tests__/ListItem.spec.tsx
@@ -28,34 +28,42 @@ describe('ListItem', () => {
   );
 
   it('triggers the deleting messages when clicked on the delete messages button', () => {
-    const component = shallow(setupComponent());
-    component.find('DropdownItem').at(0).simulate('click');
-    expect(mockDeleteMessages).toBeCalledTimes(1);
-    expect(mockDeleteMessages).toBeCalledWith(
-      clusterName,
-      internalTopicPayload.name
-    );
+    if (!internalTopicPayload.internal) {
+      const component = shallow(setupComponent());
+      component.find('DropdownItem').at(0).simulate('click');
+      expect(mockDeleteMessages).toBeCalledTimes(1);
+      expect(mockDeleteMessages).toBeCalledWith(
+        clusterName,
+        internalTopicPayload.name
+      );
+    }
   });
 
   it('triggers the deleteTopic when clicked on the delete button', () => {
-    const wrapper = shallow(setupComponent());
-    expect(wrapper.find('mock-ConfirmationModal').prop('isOpen')).toBeFalsy();
-    wrapper.find('DropdownItem').at(1).simulate('click');
-    const modal = wrapper.find('mock-ConfirmationModal');
-    expect(modal.prop('isOpen')).toBeTruthy();
-    modal.simulate('confirm');
-    expect(mockDelete).toBeCalledTimes(1);
-    expect(mockDelete).toBeCalledWith(clusterName, internalTopicPayload.name);
+    if (!internalTopicPayload.internal) {
+      const wrapper = shallow(setupComponent());
+      expect(wrapper.find('mock-ConfirmationModal').prop('isOpen')).toBeFalsy();
+      wrapper.find('DropdownItem').at(1).simulate('click');
+      const modal = wrapper.find('mock-ConfirmationModal');
+      expect(modal.prop('isOpen')).toBeTruthy();
+      modal.simulate('confirm');
+      expect(mockDelete).toBeCalledTimes(1);
+      expect(mockDelete).toBeCalledWith(clusterName, internalTopicPayload.name);
+    }
   });
 
   it('closes ConfirmationModal when clicked on the cancel button', () => {
-    const wrapper = shallow(setupComponent());
-    expect(wrapper.find('mock-ConfirmationModal').prop('isOpen')).toBeFalsy();
-    wrapper.find('DropdownItem').last().simulate('click');
-    expect(wrapper.find('mock-ConfirmationModal').prop('isOpen')).toBeTruthy();
-    wrapper.find('mock-ConfirmationModal').simulate('cancel');
-    expect(mockDelete).toBeCalledTimes(0);
-    expect(wrapper.find('mock-ConfirmationModal').prop('isOpen')).toBeFalsy();
+    if (!internalTopicPayload.internal) {
+      const wrapper = shallow(setupComponent());
+      expect(wrapper.find('mock-ConfirmationModal').prop('isOpen')).toBeFalsy();
+      wrapper.find('DropdownItem').last().simulate('click');
+      expect(
+        wrapper.find('mock-ConfirmationModal').prop('isOpen')
+      ).toBeTruthy();
+      wrapper.find('mock-ConfirmationModal').simulate('cancel');
+      expect(mockDelete).toBeCalledTimes(0);
+      expect(wrapper.find('mock-ConfirmationModal').prop('isOpen')).toBeFalsy();
+    }
   });
 
   it('renders correct tags for internal topic', () => {

--- a/kafka-ui-react-app/src/components/Topics/List/__tests__/ListItem.spec.tsx
+++ b/kafka-ui-react-app/src/components/Topics/List/__tests__/ListItem.spec.tsx
@@ -28,42 +28,37 @@ describe('ListItem', () => {
   );
 
   it('triggers the deleting messages when clicked on the delete messages button', () => {
-    if (!internalTopicPayload.internal) {
-      const component = shallow(setupComponent());
-      component.find('DropdownItem').at(0).simulate('click');
-      expect(mockDeleteMessages).toBeCalledTimes(1);
-      expect(mockDeleteMessages).toBeCalledWith(
-        clusterName,
-        internalTopicPayload.name
-      );
-    }
+    const component = shallow(setupComponent({ topic: externalTopicPayload }));
+    expect(component.exists('.value')).toBeTruthy();
+    component.find('DropdownItem').at(0).simulate('click');
+    expect(mockDeleteMessages).toBeCalledTimes(1);
+    expect(mockDeleteMessages).toBeCalledWith(
+      clusterName,
+      externalTopicPayload.name
+    );
   });
 
   it('triggers the deleteTopic when clicked on the delete button', () => {
-    if (!internalTopicPayload.internal) {
-      const wrapper = shallow(setupComponent());
-      expect(wrapper.find('mock-ConfirmationModal').prop('isOpen')).toBeFalsy();
-      wrapper.find('DropdownItem').at(1).simulate('click');
-      const modal = wrapper.find('mock-ConfirmationModal');
-      expect(modal.prop('isOpen')).toBeTruthy();
-      modal.simulate('confirm');
-      expect(mockDelete).toBeCalledTimes(1);
-      expect(mockDelete).toBeCalledWith(clusterName, internalTopicPayload.name);
-    }
+    const wrapper = shallow(setupComponent({ topic: externalTopicPayload }));
+    expect(wrapper.exists('.value')).toBeTruthy();
+    expect(wrapper.find('mock-ConfirmationModal').prop('isOpen')).toBeFalsy();
+    wrapper.find('DropdownItem').at(1).simulate('click');
+    const modal = wrapper.find('mock-ConfirmationModal');
+    expect(modal.prop('isOpen')).toBeTruthy();
+    modal.simulate('confirm');
+    expect(mockDelete).toBeCalledTimes(1);
+    expect(mockDelete).toBeCalledWith(clusterName, externalTopicPayload.name);
   });
 
   it('closes ConfirmationModal when clicked on the cancel button', () => {
-    if (!internalTopicPayload.internal) {
-      const wrapper = shallow(setupComponent());
-      expect(wrapper.find('mock-ConfirmationModal').prop('isOpen')).toBeFalsy();
-      wrapper.find('DropdownItem').last().simulate('click');
-      expect(
-        wrapper.find('mock-ConfirmationModal').prop('isOpen')
-      ).toBeTruthy();
-      wrapper.find('mock-ConfirmationModal').simulate('cancel');
-      expect(mockDelete).toBeCalledTimes(0);
-      expect(wrapper.find('mock-ConfirmationModal').prop('isOpen')).toBeFalsy();
-    }
+    const wrapper = shallow(setupComponent({ topic: externalTopicPayload }));
+    expect(wrapper.exists('.value')).toBeTruthy();
+    expect(wrapper.find('mock-ConfirmationModal').prop('isOpen')).toBeFalsy();
+    wrapper.find('DropdownItem').last().simulate('click');
+    expect(wrapper.find('mock-ConfirmationModal').prop('isOpen')).toBeTruthy();
+    wrapper.find('mock-ConfirmationModal').simulate('cancel');
+    expect(mockDelete).toBeCalledTimes(0);
+    expect(wrapper.find('mock-ConfirmationModal').prop('isOpen')).toBeFalsy();
   });
 
   it('renders correct tags for internal topic', () => {

--- a/kafka-ui-react-app/src/components/Topics/List/__tests__/ListItem.spec.tsx
+++ b/kafka-ui-react-app/src/components/Topics/List/__tests__/ListItem.spec.tsx
@@ -29,7 +29,7 @@ describe('ListItem', () => {
 
   it('triggers the deleting messages when clicked on the delete messages button', () => {
     const component = shallow(setupComponent({ topic: externalTopicPayload }));
-    expect(component.exists('.value')).toBeTruthy();
+    expect(component.exists('.topic-action-block')).toBeTruthy();
     component.find('DropdownItem').at(0).simulate('click');
     expect(mockDeleteMessages).toBeCalledTimes(1);
     expect(mockDeleteMessages).toBeCalledWith(
@@ -40,7 +40,7 @@ describe('ListItem', () => {
 
   it('triggers the deleteTopic when clicked on the delete button', () => {
     const wrapper = shallow(setupComponent({ topic: externalTopicPayload }));
-    expect(wrapper.exists('.value')).toBeTruthy();
+    expect(wrapper.exists('.topic-action-block')).toBeTruthy();
     expect(wrapper.find('mock-ConfirmationModal').prop('isOpen')).toBeFalsy();
     wrapper.find('DropdownItem').at(1).simulate('click');
     const modal = wrapper.find('mock-ConfirmationModal');
@@ -52,7 +52,7 @@ describe('ListItem', () => {
 
   it('closes ConfirmationModal when clicked on the cancel button', () => {
     const wrapper = shallow(setupComponent({ topic: externalTopicPayload }));
-    expect(wrapper.exists('.value')).toBeTruthy();
+    expect(wrapper.exists('.topic-action-block')).toBeTruthy();
     expect(wrapper.find('mock-ConfirmationModal').prop('isOpen')).toBeFalsy();
     wrapper.find('DropdownItem').last().simulate('click');
     expect(wrapper.find('mock-ConfirmationModal').prop('isOpen')).toBeTruthy();

--- a/kafka-ui-react-app/src/components/Topics/Topic/Details/Details.tsx
+++ b/kafka-ui-react-app/src/components/Topics/Topic/Details/Details.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ClusterName, TopicName, RootState } from 'redux/interfaces';
+import { ClusterName, TopicName } from 'redux/interfaces';
 import { Topic, TopicDetails } from 'generated-sources';
 import { NavLink, Switch, Route, Link, useHistory } from 'react-router-dom';
 import {
@@ -19,7 +19,7 @@ import SettingsContainer from './Settings/SettingsContainer';
 interface Props extends Topic, TopicDetails {
   clusterName: ClusterName;
   topicName: TopicName;
-  state: RootState;
+  isInternal: boolean | undefined;
   deleteTopic: (clusterName: ClusterName, topicName: TopicName) => void;
   clearTopicMessages(clusterName: ClusterName, topicName: TopicName): void;
 }
@@ -27,12 +27,10 @@ interface Props extends Topic, TopicDetails {
 const Details: React.FC<Props> = ({
   clusterName,
   topicName,
-  state,
+  isInternal,
   deleteTopic,
   clearTopicMessages,
 }) => {
-  const isInternal = state.topics.byName[topicName].internal;
-
   const history = useHistory();
   const { isReadOnly } = React.useContext(ClusterContext);
   const [
@@ -78,8 +76,8 @@ const Details: React.FC<Props> = ({
           </NavLink>
         </div>
         <div className="navbar-end">
-          <div className="buttons">
-            {!isReadOnly && !isInternal ? (
+          {!isReadOnly && !isInternal ? (
+            <div className="buttons">
               <>
                 <button
                   type="button"
@@ -111,8 +109,8 @@ const Details: React.FC<Props> = ({
                   Are you sure want to remove <b>{topicName}</b> topic?
                 </ConfirmationModal>
               </>
-            ) : null}
-          </div>
+            </div>
+          ) : null}
         </div>
       </nav>
       <br />

--- a/kafka-ui-react-app/src/components/Topics/Topic/Details/Details.tsx
+++ b/kafka-ui-react-app/src/components/Topics/Topic/Details/Details.tsx
@@ -19,7 +19,7 @@ import SettingsContainer from './Settings/SettingsContainer';
 interface Props extends Topic, TopicDetails {
   clusterName: ClusterName;
   topicName: TopicName;
-  isInternal: boolean | undefined;
+  isInternal: boolean;
   deleteTopic: (clusterName: ClusterName, topicName: TopicName) => void;
   clearTopicMessages(clusterName: ClusterName, topicName: TopicName): void;
 }

--- a/kafka-ui-react-app/src/components/Topics/Topic/Details/Details.tsx
+++ b/kafka-ui-react-app/src/components/Topics/Topic/Details/Details.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ClusterName, TopicName } from 'redux/interfaces';
+import { ClusterName, TopicName, RootState } from 'redux/interfaces';
 import { Topic, TopicDetails } from 'generated-sources';
 import { NavLink, Switch, Route, Link, useHistory } from 'react-router-dom';
 import {
@@ -19,6 +19,7 @@ import SettingsContainer from './Settings/SettingsContainer';
 interface Props extends Topic, TopicDetails {
   clusterName: ClusterName;
   topicName: TopicName;
+  state: RootState;
   deleteTopic: (clusterName: ClusterName, topicName: TopicName) => void;
   clearTopicMessages(clusterName: ClusterName, topicName: TopicName): void;
 }
@@ -26,9 +27,12 @@ interface Props extends Topic, TopicDetails {
 const Details: React.FC<Props> = ({
   clusterName,
   topicName,
+  state,
   deleteTopic,
   clearTopicMessages,
 }) => {
+  const isInternal = state.topics.byName[topicName].internal;
+
   const history = useHistory();
   const { isReadOnly } = React.useContext(ClusterContext);
   const [
@@ -75,7 +79,7 @@ const Details: React.FC<Props> = ({
         </div>
         <div className="navbar-end">
           <div className="buttons">
-            {!isReadOnly && (
+            {!isReadOnly && !isInternal ? (
               <>
                 <button
                   type="button"
@@ -107,7 +111,7 @@ const Details: React.FC<Props> = ({
                   Are you sure want to remove <b>{topicName}</b> topic?
                 </ConfirmationModal>
               </>
-            )}
+            ) : null}
           </div>
         </div>
       </nav>

--- a/kafka-ui-react-app/src/components/Topics/Topic/Details/DetailsContainer.ts
+++ b/kafka-ui-react-app/src/components/Topics/Topic/Details/DetailsContainer.ts
@@ -2,6 +2,7 @@ import { connect } from 'react-redux';
 import { ClusterName, RootState, TopicName } from 'redux/interfaces';
 import { withRouter, RouteComponentProps } from 'react-router-dom';
 import { deleteTopic, clearTopicMessages } from 'redux/actions';
+import { getIsTopicInternal } from 'redux/reducers/topics/selectors';
 
 import Details from './Details';
 
@@ -22,7 +23,7 @@ const mapStateToProps = (
 ) => ({
   clusterName,
   topicName,
-  isInternal: state.topics.byName[topicName].internal,
+  isInternal: getIsTopicInternal(state, topicName),
 });
 
 const mapDispatchToProps = {

--- a/kafka-ui-react-app/src/components/Topics/Topic/Details/DetailsContainer.ts
+++ b/kafka-ui-react-app/src/components/Topics/Topic/Details/DetailsContainer.ts
@@ -22,6 +22,7 @@ const mapStateToProps = (
 ) => ({
   clusterName,
   topicName,
+  state,
 });
 
 const mapDispatchToProps = {

--- a/kafka-ui-react-app/src/components/Topics/Topic/Details/DetailsContainer.ts
+++ b/kafka-ui-react-app/src/components/Topics/Topic/Details/DetailsContainer.ts
@@ -22,7 +22,7 @@ const mapStateToProps = (
 ) => ({
   clusterName,
   topicName,
-  state,
+  isInternal: state.topics.byName[topicName].internal,
 });
 
 const mapDispatchToProps = {

--- a/kafka-ui-react-app/src/components/Topics/Topic/Details/Overview/Overview.tsx
+++ b/kafka-ui-react-app/src/components/Topics/Topic/Details/Overview/Overview.tsx
@@ -75,22 +75,24 @@ const Overview: React.FC<Props> = ({
               <td>{offsetMin}</td>
               <td>{offsetMax}</td>
               <td className="has-text-right">
-                <Dropdown
-                  label={
-                    <span className="icon">
-                      <i className="fas fa-cog" />
-                    </span>
-                  }
-                  right
-                >
-                  <DropdownItem
-                    onClick={() =>
-                      clearTopicMessages(clusterName, topicName, [partition])
+                {!internal ? (
+                  <Dropdown
+                    label={
+                      <span className="icon">
+                        <i className="fas fa-cog" />
+                      </span>
                     }
+                    right
                   >
-                    <span className="has-text-danger">Clear Messages</span>
-                  </DropdownItem>
-                </Dropdown>
+                    <DropdownItem
+                      onClick={() =>
+                        clearTopicMessages(clusterName, topicName, [partition])
+                      }
+                    >
+                      <span className="has-text-danger">Clear Messages</span>
+                    </DropdownItem>
+                  </Dropdown>
+                ) : null}
               </td>
             </tr>
           ))}

--- a/kafka-ui-react-app/src/components/Topics/Topic/Details/Overview/Overview.tsx
+++ b/kafka-ui-react-app/src/components/Topics/Topic/Details/Overview/Overview.tsx
@@ -74,8 +74,8 @@ const Overview: React.FC<Props> = ({
               <td>{leader}</td>
               <td>{offsetMin}</td>
               <td>{offsetMax}</td>
-              {!internal ? (
-                <td className="has-text-right">
+              <td className="has-text-right">
+                {!internal ? (
                   <Dropdown
                     label={
                       <span className="icon">
@@ -92,8 +92,8 @@ const Overview: React.FC<Props> = ({
                       <span className="has-text-danger">Clear Messages</span>
                     </DropdownItem>
                   </Dropdown>
-                </td>
-              ) : null}
+                ) : null}
+              </td>
             </tr>
           ))}
         </tbody>

--- a/kafka-ui-react-app/src/components/Topics/Topic/Details/Overview/Overview.tsx
+++ b/kafka-ui-react-app/src/components/Topics/Topic/Details/Overview/Overview.tsx
@@ -74,8 +74,8 @@ const Overview: React.FC<Props> = ({
               <td>{leader}</td>
               <td>{offsetMin}</td>
               <td>{offsetMax}</td>
-              <td className="has-text-right">
-                {!internal ? (
+              {!internal ? (
+                <td className="has-text-right">
                   <Dropdown
                     label={
                       <span className="icon">
@@ -92,8 +92,8 @@ const Overview: React.FC<Props> = ({
                       <span className="has-text-danger">Clear Messages</span>
                     </DropdownItem>
                   </Dropdown>
-                ) : null}
-              </td>
+                </td>
+              ) : null}
             </tr>
           ))}
         </tbody>

--- a/kafka-ui-react-app/src/components/Topics/Topic/Details/Overview/__test__/Overview.spec.tsx
+++ b/kafka-ui-react-app/src/components/Topics/Topic/Details/Overview/__test__/Overview.spec.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import Overview from 'components/Topics/Topic/Details/Overview/Overview';
+
+describe('Overview', () => {
+  const mockInternal = false;
+  const mockClusterName = 'local';
+  const mockTopicName = 'topic';
+  const mockClearTopicMessages = jest.fn();
+  const mockPartitions = [
+    {
+      partition: 1,
+      leader: 1,
+      replicas: [
+        {
+          broker: 1,
+          leader: false,
+          inSync: true,
+        },
+      ],
+      offsetMax: 0,
+      offsetMin: 0,
+    },
+  ];
+
+  describe('when it has internal flag', () => {
+    it('does not render the Action button a Topic', () => {
+      const component = shallow(
+        <Overview
+          name={mockTopicName}
+          partitions={mockPartitions}
+          internal={mockInternal}
+          clusterName={mockClusterName}
+          topicName={mockTopicName}
+          clearTopicMessages={mockClearTopicMessages}
+        />
+      );
+
+      expect(component.exists('Dropdown')).toBeTruthy();
+    });
+  });
+});

--- a/kafka-ui-react-app/src/components/Topics/Topic/Details/__test__/Details.spec.tsx
+++ b/kafka-ui-react-app/src/components/Topics/Topic/Details/__test__/Details.spec.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { StaticRouter } from 'react-router-dom';
+import ClusterContext from 'components/contexts/ClusterContext';
+import Details from 'components/Topics/Topic/Details/Details';
+import {
+  internalTopicPayload,
+  externalTopicPayload,
+} from 'redux/reducers/topics/__test__/fixtures';
+
+describe('Details', () => {
+  const mockDelete = jest.fn();
+  const mockClusterName = 'local';
+  const mockClearTopicMessages = jest.fn();
+  const mockInternalTopicPayload = internalTopicPayload.internal;
+  const mockExternalTopicPayload = externalTopicPayload.internal;
+
+  describe('when it has readonly flag', () => {
+    it('does not render the Action button a Topic', () => {
+      const component = mount(
+        <StaticRouter>
+          <ClusterContext.Provider
+            value={{
+              isReadOnly: true,
+              hasKafkaConnectConfigured: true,
+              hasSchemaRegistryConfigured: true,
+            }}
+          >
+            <Details
+              clusterName={mockClusterName}
+              topicName={internalTopicPayload.name}
+              name={internalTopicPayload.name}
+              isInternal={mockInternalTopicPayload}
+              deleteTopic={mockDelete}
+              clearTopicMessages={mockClearTopicMessages}
+            />
+          </ClusterContext.Provider>
+        </StaticRouter>
+      );
+
+      expect(component.exists('button')).toBeFalsy();
+    });
+  });
+
+  describe('when it does not have readonly flag', () => {
+    it('renders the Action button a Topic', () => {
+      const component = mount(
+        <StaticRouter>
+          <ClusterContext.Provider
+            value={{
+              isReadOnly: false,
+              hasKafkaConnectConfigured: true,
+              hasSchemaRegistryConfigured: true,
+            }}
+          >
+            <Details
+              clusterName={mockClusterName}
+              topicName={internalTopicPayload.name}
+              name={internalTopicPayload.name}
+              isInternal={mockExternalTopicPayload}
+              deleteTopic={mockDelete}
+              clearTopicMessages={mockClearTopicMessages}
+            />
+          </ClusterContext.Provider>
+        </StaticRouter>
+      );
+
+      expect(component.exists('button')).toBeTruthy();
+    });
+  });
+});

--- a/kafka-ui-react-app/src/redux/reducers/topics/selectors.ts
+++ b/kafka-ui-react-app/src/redux/reducers/topics/selectors.ts
@@ -123,3 +123,8 @@ export const getTopicConfigByParamName = createSelector(
     return byParamName;
   }
 );
+
+export const getIsTopicInternal = createSelector(
+  getTopicByName,
+  ({ internal }) => !!internal
+);


### PR DESCRIPTION
User should not be able to update/delete internal topics. Add confirmation for all delete/reset actions
<img width="612" alt="Screenshot 2021-04-25 at 21 18 12" src="https://user-images.githubusercontent.com/34422286/116004530-c0893280-a60b-11eb-926a-73f4ac60ac21.png">

if topic is internal you don't see an action button 

<img width="595" alt="Screenshot 2021-04-25 at 21 18 39" src="https://user-images.githubusercontent.com/34422286/116004592-1bbb2500-a60c-11eb-92f4-1512f2a610e5.png">

<img width="593" alt="Screenshot 2021-04-25 at 21 18 52" src="https://user-images.githubusercontent.com/34422286/116004604-3097b880-a60c-11eb-9668-03f410f57678.png">
