### PR TITLE
Use spring oauth2 starter as dependency 

### DIFF
--- a/kafka-ui-api/pom.xml
+++ b/kafka-ui-api/pom.xml
@@ -38,8 +38,8 @@
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework.security</groupId>
-            <artifactId>spring-security-oauth2-client</artifactId>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-client</artifactId>	
         </dependency>
         <dependency>
             <groupId>com.provectus</groupId>


### PR DESCRIPTION
Spring starter add additional dependency `spring-security-oauth2-jose`. It is needed if you want to configure generic oauth provider such as AWS cognito.