### PR TITLE
Remove default cluster configuration.

### DIFF
--- a/kafka-ui-api/src/main/resources/application.yml
+++ b/kafka-ui-api/src/main/resources/application.yml
@@ -1,9 +1,4 @@
 kafka:
-  clusters:
-    - name: local
-      bootstrapServers: localhost:9092
-      zookeeper: localhost:2181
-      schemaRegistry: http://localhost:8081
   admin-client-timeout: 5000
 zookeeper:
   connection-timeout: 1000


### PR DESCRIPTION
When this default cluster configuration is setup, user have to override complete first cluster. Eg have to set KAFKA_CLUSTERS_0_ZOOKEEPER to empty string to override default localhost.