### PR TITLE
feat: Helm chart ingress refactor and SSL redirect

### DIFF
--- a/charts/kafka-ui/templates/ingress.yaml
+++ b/charts/kafka-ui/templates/ingress.yaml
@@ -16,26 +16,34 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if .Values.ingress.tls }}
+  {{- if .Values.ingress.tls.enabled }}
   tls:
-    {{- range .Values.ingress.tls }}
     - hosts:
-        {{- range .hosts }}
-        - {{ . | quote }}
-        {{- end }}
-      secretName: {{ .secretName }}
-    {{- end }}
+        - {{ .Values.ingress.host }}
+      secretName: {{ .Values.ingress.tls.secretName }}
   {{- end }}
   rules:
-    {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
-      http:
+    - http:
         paths:
-          {{- range .paths }}
-          - path: {{ . }}
+          {{- range .Values.ingress.precedingPaths }}
+          - path: {{ .path }}
             backend:
+              serviceName: {{ .serviceName }}
+              servicePort: {{ .servicePort }}
+          {{- end }}
+          - backend:
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
+{{- if .Values.ingress.path }}
+            path: {{ .Values.ingress.path }}
+{{- end }}
+          {{- range .Values.ingress.succeedingPaths }}
+          - path: {{ .path }}
+            backend:
+              serviceName: {{ .serviceName }}
+              servicePort: {{ .servicePort }}
           {{- end }}
-    {{- end }}
+{{- if .Values.ingress.host }}
+      host: {{ .Values.ingress.host }}
+{{- end }}
   {{- end }}

--- a/charts/kafka-ui/values.yaml
+++ b/charts/kafka-ui/values.yaml
@@ -44,13 +44,32 @@ service:
   # if you want to force a specific nodePort. Must be use with service.type=NodePort
   # nodePort:
 
+# Ingress configuration
 ingress:
+  # Enable ingress resource
   enabled: false
+
+  # Annotations for the Ingress
   annotations: {}
-  hosts:
-    - host: chart-example.local
-      paths: []
-  tls: []
+
+  # The path for the Ingress
+  path: ""
+
+  # The hostname for the Ingress
+  host: ""
+
+  # configs for Ingress TLS
+  tls:
+    # Enable TLS termination for the Ingress
+    enabled: false
+    # the name of a pre-created Secret containing a TLS private key and certificate
+    secretName: ""
+
+  # HTTP paths to add to the Ingress before the default path
+  precedingPaths: []
+
+  # Http paths to add to the Ingress after the default path
+  succeedingPaths: []
 
 resources: {}
   # limits:


### PR DESCRIPTION
Introducing precedingPaths in the Ingress object. With the help of the precedingPaths you can to SSL redirect on the ingress controller side. Inspired by Airflow Helm chart web ingress object.

BREAKING CHANGE: Ingress object changed.

<!-- ignore-task-list-start -->
- [X] **Breaking change?** (if so, please describe the impact and migration path for existing applications:)
- Helm chart ingress object configuration changed
<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)
Introducing precedingPaths in the Ingress object. With the help of the precedingPaths you can to SSL redirect on the ingress controller side. Inspired by Airflow Helm chart web ingress object.

**Is there anything you'd like reviewers to focus on?**


**How Has This Been Tested?** (put an "X" next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [X] Manually(please, describe, when necessary)
Deployin helm chart to an EKS cluster
- [ ] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "X" next to an item, otherwise PR will fail)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [X] My changes generate no new warnings(e.g. Sonar is happy)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged

Check out [Contributing](https://github.com/provectus/kafka-ui/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/provectus/kafka-ui/blob/master/CODE-OF-CONDUCT.md)