### PR TITLE
[Kafka Connect] Fix getting list of connector's topics

### DIFF
--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/model/connect/InternalConnectInfo.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/model/connect/InternalConnectInfo.java
@@ -1,0 +1,17 @@
+package com.provectus.kafka.ui.model.connect;
+
+import com.provectus.kafka.ui.model.Connector;
+import com.provectus.kafka.ui.model.Task;
+import java.util.List;
+import java.util.Map;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder(toBuilder = true)
+public class InternalConnectInfo {
+  private final Connector connector;
+  private final Map<String, Object> config;
+  private final List<Task> tasks;
+  private final List<String> topics;
+}

--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/service/KafkaConnectService.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/service/KafkaConnectService.java
@@ -65,19 +65,17 @@ public class KafkaConnectService {
                     .build()
                 )
         )
-        .flatMap(connectInfo ->
-            {
-              Connector connector = connectInfo.getConnector();
-              return getConnectorTasks(clusterName, connector.getConnect(), connector.getName())
-                  .collectList()
-                  .map(tasks -> InternalConnectInfo.builder()
-                      .connector(connector)
-                      .config(connectInfo.getConfig())
-                      .tasks(tasks)
-                      .build()
-                  );
-            }
-        )
+        .flatMap(connectInfo -> {
+          Connector connector = connectInfo.getConnector();
+          return getConnectorTasks(clusterName, connector.getConnect(), connector.getName())
+              .collectList()
+              .map(tasks -> InternalConnectInfo.builder()
+                  .connector(connector)
+                  .config(connectInfo.getConfig())
+                  .tasks(tasks)
+                  .build()
+              );
+        })
         .flatMap(connectInfo -> {
           Connector connector = connectInfo.getConnector();
           return getConnectorTopics(clusterName, connector.getConnect(), connector.getName())

--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/service/KafkaConnectService.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/service/KafkaConnectService.java
@@ -3,6 +3,7 @@ package com.provectus.kafka.ui.service;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.provectus.kafka.ui.client.KafkaConnectClients;
+import com.provectus.kafka.ui.connect.model.ConnectorTopics;
 import com.provectus.kafka.ui.exception.ClusterNotFoundException;
 import com.provectus.kafka.ui.exception.ConnectNotFoundException;
 import com.provectus.kafka.ui.mapper.ClusterMapper;
@@ -17,6 +18,7 @@ import com.provectus.kafka.ui.model.KafkaCluster;
 import com.provectus.kafka.ui.model.KafkaConnectCluster;
 import com.provectus.kafka.ui.model.NewConnector;
 import com.provectus.kafka.ui.model.Task;
+import com.provectus.kafka.ui.model.connect.InternalConnectInfo;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -26,7 +28,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.commons.lang3.tuple.Triple;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -58,14 +59,40 @@ public class KafkaConnectService {
         .flatMap(pair -> getConnector(clusterName, pair.getLeft(), pair.getRight()))
         .flatMap(connector ->
             getConnectorConfig(clusterName, connector.getConnect(), connector.getName())
-                .map(config -> Pair.of(connector, config))
+                .map(config -> InternalConnectInfo.builder()
+                    .connector(connector)
+                    .config(config)
+                    .build()
+                )
         )
-        .flatMap(pair ->
-            getConnectorTasks(clusterName, pair.getLeft().getConnect(), pair.getLeft().getName())
+        .flatMap(connectInfo ->
+            getConnectorTasks(clusterName, connectInfo.getConnector().getConnect(), connectInfo.getConnector().getName())
                 .collectList()
-                .map(tasks -> Triple.of(pair.getLeft(), pair.getRight(), tasks))
+                .map(tasks -> InternalConnectInfo.builder()
+                    .connector(connectInfo.getConnector())
+                    .config(connectInfo.getConfig())
+                    .tasks(tasks)
+                    .build()
+                )
         )
+        .flatMap(connectInfo -> getConnectorTopics(clusterName, connectInfo.getConnector().getConnect(), connectInfo.getConnector().getName())
+            .map(ct -> InternalConnectInfo.builder()
+                .connector(connectInfo.getConnector())
+                .config(connectInfo.getConfig())
+                .tasks(connectInfo.getTasks())
+                .topics(ct.getTopics())
+                .build()
+            ))
         .map(kafkaConnectMapper::fullConnectorInfoFromTuple);
+  }
+
+  private Mono<ConnectorTopics> getConnectorTopics(String clusterName, String kafkaConnectClusterName, String connectorName) {
+    return getConnectAddress(clusterName, kafkaConnectClusterName)
+        .flatMap(connectUrl -> KafkaConnectClients
+            .withBaseUrl(connectUrl)
+            .getConnectorTopics(connectorName)
+            .map(result -> result.get(connectorName))
+        );
   }
 
   private Flux<Pair<String, String>> getConnectorNames(String clusterName, Connect connect) {

--- a/kafka-ui-contract/src/main/resources/swagger/kafka-connect-api.yaml
+++ b/kafka-ui-contract/src/main/resources/swagger/kafka-connect-api.yaml
@@ -231,6 +231,28 @@ paths:
                 items:
                   $ref: '#/components/schemas/ConnectorTask'
 
+  /connectors/{connectorName}/topics:
+    get:
+      tags:
+        - KafkaConnectClient
+      summary: The set of topic names the connector has been using since its creation or since the last time its set of active topics was reset
+      operationId: getConnectorTopics
+      parameters:
+        - name: connectorName
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  $ref: '#/components/schemas/ConnectorTopics'
+
   /connectors/{connectorName}/tasks/{taskId}/status:
     get:
       tags:
@@ -498,4 +520,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ConnectorPluginConfig'
+
+    ConnectorTopics:
+      type: object
+      properties:
+        topics:
+          type: array
+          items:
+            type: string
 


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing applications:)
<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)
Now we can get a valid list of topics that are used by a connector.
If the connector type is **SOURCE**, then the list is where it sends messages,
If the connector type is **SINK**, where it consumes from.

**After**
The connectors are set up to deal with multiple topics. Some of them use regexs or `topic`, `topics` properties  
<img width="1236" alt="Screenshot 2021-05-30 at 19 00 12" src="https://user-images.githubusercontent.com/11831199/120112049-efe80d80-c17c-11eb-9b73-e90db2f0b70b.png">


**Is there anything you'd like reviewers to focus on?**


**How Has This Been Tested?** (put an "X" next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually(please, describe, when necessary)
- [ ] Unit checks
- [ ] Integration checks
- [x] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "X" next to an item, otherwise PR will fail)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [ ] My changes generate no new warnings(e.g. Sonar is happy)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/provectus/kafka-ui/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/provectus/kafka-ui/blob/master/CODE-OF-CONDUCT.md)