### PR TITLE
Add SeekDirection to the GET topic messages request

### DIFF
--- a/kafka-ui-contract/src/main/resources/swagger/kafka-ui-api.yaml
+++ b/kafka-ui-contract/src/main/resources/swagger/kafka-ui-api.yaml
@@ -323,6 +323,10 @@ paths:
           in: query
           schema:
             type: string
+        - name: seekDirection
+          in: query
+          schema:
+            $ref: "#/components/schemas/SeekDirection"
       responses:
         200:
           description: OK
@@ -1447,6 +1451,12 @@ components:
         - BEGINNING
         - OFFSET
         - TIMESTAMP
+
+    SeekDirection:
+      type: string
+      enum:
+        - FORWARD
+        - BACKWARD
 
     Partition:
       type: object


### PR DESCRIPTION
Introduced the new query field for the GET topic message request - seekDirection. It can have two values - _FORWARD_ (forward in time, show messages starting from the oldest ones) and _BACKWARD_ (backward in time, show messages starting from the newest ones). I'm not sure if these literals are the best choice for the values. Maybe something like _NEWEST_FIRST_ and _OLDEST_FIRST_ is more intuitively understandable.
The front-end implementation plan is to have some kind of a toggle, which controls the sorting direction of the list. 