### PR TITLE
Add wrapping for topic names

### DIFF
--- a/kafka-ui-react-app/src/components/Connect/List/ListItem.tsx
+++ b/kafka-ui-react-app/src/components/Connect/List/ListItem.tsx
@@ -63,11 +63,11 @@ const ListItem: React.FC<ListItemProps> = ({
       <td>{connect}</td>
       <td>{type}</td>
       <td>{connectorClass}</td>
-      <td>
+      <td className="is-flex is-flex-wrap-wrap">
         {topics?.map((t) => (
-          <Link className="mr-1" key={t} to={clusterTopicPath(clusterName, t)}>
-            {t}
-          </Link>
+          <span key={t} className="tag is-info is-light mr-1 mb-1">
+            <Link to={clusterTopicPath(clusterName, t)}>{t}</Link>
+          </span>
         ))}
       </td>
       <td>{status && <StatusTag status={status.state} />}</td>

--- a/kafka-ui-react-app/src/components/Connect/List/ListItem.tsx
+++ b/kafka-ui-react-app/src/components/Connect/List/ListItem.tsx
@@ -63,12 +63,14 @@ const ListItem: React.FC<ListItemProps> = ({
       <td>{connect}</td>
       <td>{type}</td>
       <td>{connectorClass}</td>
-      <td className="is-flex is-flex-wrap-wrap">
-        {topics?.map((t) => (
-          <span key={t} className="tag is-info is-light mr-1 mb-1">
-            <Link to={clusterTopicPath(clusterName, t)}>{t}</Link>
-          </span>
-        ))}
+      <td>
+        <div className="is-flex is-flex-wrap-wrap">
+          {topics?.map((t) => (
+            <span key={t} className="tag is-info is-light mr-1 mb-1">
+              <Link to={clusterTopicPath(clusterName, t)}>{t}</Link>
+            </span>
+          ))}
+        </div>
       </td>
       <td>{status && <StatusTag status={status.state} />}</td>
       <td>

--- a/kafka-ui-react-app/src/components/Connect/List/__tests__/__snapshots__/ListItem.spec.tsx.snap
+++ b/kafka-ui-react-app/src/components/Connect/List/__tests__/__snapshots__/ListItem.spec.tsx.snap
@@ -105,29 +105,31 @@ exports[`Connectors ListItem matches snapshot 1`] = `
               <td>
                 FileStreamSource
               </td>
-              <td
-                className="is-flex is-flex-wrap-wrap"
-              >
-                <span
-                  className="tag is-info is-light mr-1 mb-1"
-                  key="test-topic"
+              <td>
+                <div
+                  className="is-flex is-flex-wrap-wrap"
                 >
-                  <Link
-                    to="/ui/clusters/local/topics/test-topic"
+                  <span
+                    className="tag is-info is-light mr-1 mb-1"
+                    key="test-topic"
                   >
-                    <LinkAnchor
-                      href="/ui/clusters/local/topics/test-topic"
-                      navigate={[Function]}
+                    <Link
+                      to="/ui/clusters/local/topics/test-topic"
                     >
-                      <a
+                      <LinkAnchor
                         href="/ui/clusters/local/topics/test-topic"
-                        onClick={[Function]}
+                        navigate={[Function]}
                       >
-                        test-topic
-                      </a>
-                    </LinkAnchor>
-                  </Link>
-                </span>
+                        <a
+                          href="/ui/clusters/local/topics/test-topic"
+                          onClick={[Function]}
+                        >
+                          test-topic
+                        </a>
+                      </LinkAnchor>
+                    </Link>
+                  </span>
+                </div>
               </td>
               <td>
                 <StatusTag

--- a/kafka-ui-react-app/src/components/Connect/List/__tests__/__snapshots__/ListItem.spec.tsx.snap
+++ b/kafka-ui-react-app/src/components/Connect/List/__tests__/__snapshots__/ListItem.spec.tsx.snap
@@ -105,26 +105,29 @@ exports[`Connectors ListItem matches snapshot 1`] = `
               <td>
                 FileStreamSource
               </td>
-              <td>
-                <Link
-                  className="mr-1"
+              <td
+                className="is-flex is-flex-wrap-wrap"
+              >
+                <span
+                  className="tag is-info is-light mr-1 mb-1"
                   key="test-topic"
-                  to="/ui/clusters/local/topics/test-topic"
                 >
-                  <LinkAnchor
-                    className="mr-1"
-                    href="/ui/clusters/local/topics/test-topic"
-                    navigate={[Function]}
+                  <Link
+                    to="/ui/clusters/local/topics/test-topic"
                   >
-                    <a
-                      className="mr-1"
+                    <LinkAnchor
                       href="/ui/clusters/local/topics/test-topic"
-                      onClick={[Function]}
+                      navigate={[Function]}
                     >
-                      test-topic
-                    </a>
-                  </LinkAnchor>
-                </Link>
+                      <a
+                        href="/ui/clusters/local/topics/test-topic"
+                        onClick={[Function]}
+                      >
+                        test-topic
+                      </a>
+                    </LinkAnchor>
+                  </Link>
+                </span>
               </td>
               <td>
                 <StatusTag


### PR DESCRIPTION
Turned the table cell for topic names into the flexbox container with the `flex-wrap` property. Also, every link is now styled as a tag, so that different links are now visually separatable.
![image](https://user-images.githubusercontent.com/31561808/121170485-f56ce400-c85d-11eb-9922-4b89b015bcb4.png)
