### PR TITLE
Fix 556. Kafka-ui is available on port 8080

### DIFF
--- a/charts/kafka-ui/README.md
+++ b/charts/kafka-ui/README.md
@@ -17,6 +17,6 @@ helm install kafka-ui kafka-ui/kafka-ui --set envs.config.KAFKA_CLUSTERS_0_NAME=
 ``` 
 To connect to Kafka-UI web application need to execute:
 ``` bash
-kubectl port-forward svc/kafka-ui 8080:8080
+kubectl port-forward svc/kafka-ui 8080:80
 ```
 Open the `http://127.0.0.1:8080` on the browser to access Kafka-UI.

--- a/charts/kafka-ui/README.md
+++ b/charts/kafka-ui/README.md
@@ -17,6 +17,6 @@ helm install kafka-ui kafka-ui/kafka-ui --set envs.config.KAFKA_CLUSTERS_0_NAME=
 ``` 
 To connect to Kafka-UI web application need to execute:
 ``` bash
-kubectl port-forward svc/kafka-ui 8080:80
+kubectl port-forward svc/kafka-ui 8080:8080
 ```
 Open the `http://127.0.0.1:8080` on the browser to access Kafka-UI.

--- a/charts/kafka-ui/templates/NOTES.txt
+++ b/charts/kafka-ui/templates/NOTES.txt
@@ -17,5 +17,5 @@
 {{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "kafka-ui.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:80
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:8080
 {{- end }}


### PR DESCRIPTION
Fix #556 
Kafka-ui is available on port 8080 of the pod. So `kubectl port-forward` shall be called with 8080 as REMOTE_PORT