### PR TITLE
#122 Fix emitter to consume records in right order

### DIFF
--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/config/CustomWebFilter.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/config/CustomWebFilter.java
@@ -1,6 +1,5 @@
 package com.provectus.kafka.ui.config;
 
-import java.util.Optional;
 import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.stereotype.Component;
 import org.springframework.web.server.ServerWebExchange;

--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/emitter/BackwardRecordEmitter.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/emitter/BackwardRecordEmitter.java
@@ -1,0 +1,94 @@
+package com.provectus.kafka.ui.emitter;
+
+import com.provectus.kafka.ui.util.OffsetsSeekBackward;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.utils.Bytes;
+import reactor.core.publisher.FluxSink;
+
+@RequiredArgsConstructor
+@Log4j2
+public class BackwardRecordEmitter
+    implements java.util.function.Consumer<FluxSink<ConsumerRecord<Bytes, Bytes>>> {
+
+  private static final Duration POLL_TIMEOUT_MS = Duration.ofMillis(1000L);
+
+  private final Function<Map<String, Object>, KafkaConsumer<Bytes, Bytes>> consumerSupplier;
+  private final OffsetsSeekBackward offsetsSeek;
+
+  @Override
+  public void accept(FluxSink<ConsumerRecord<Bytes, Bytes>> sink) {
+    try (KafkaConsumer<Bytes, Bytes> configConsumer = consumerSupplier.apply(Map.of())) {
+      final List<TopicPartition> requestedPartitions =
+          offsetsSeek.getRequestedPartitions(configConsumer);
+      final int msgsPerPartition = offsetsSeek.msgsPerPartition(requestedPartitions.size());
+      try (KafkaConsumer<Bytes, Bytes> consumer =
+               consumerSupplier.apply(
+                   Map.of(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, msgsPerPartition)
+               )
+      ) {
+        final Map<TopicPartition, Long> partitionsOffsets =
+            offsetsSeek.getPartitionsOffsets(consumer);
+        log.info("partition offsets: {}", partitionsOffsets);
+        var waitingOffsets =
+            offsetsSeek.waitingOffsets(consumer, partitionsOffsets.keySet());
+        log.info("waittin offsets {} {}",
+            waitingOffsets.getBeginOffsets(),
+            waitingOffsets.getEndOffsets()
+        );
+        while (!sink.isCancelled() && !waitingOffsets.beginReached()) {
+          for (Map.Entry<TopicPartition, Long> entry : partitionsOffsets.entrySet()) {
+            final Long lowest = waitingOffsets.getBeginOffsets().get(entry.getKey().partition());
+            consumer.assign(Collections.singleton(entry.getKey()));
+            final long offset = Math.max(lowest, entry.getValue() - msgsPerPartition);
+            log.info("Polling {} from {}", entry.getKey(), offset);
+            consumer.seek(entry.getKey(), offset);
+            ConsumerRecords<Bytes, Bytes> records = consumer.poll(POLL_TIMEOUT_MS);
+            final List<ConsumerRecord<Bytes, Bytes>> partitionRecords =
+                records.records(entry.getKey()).stream()
+                  .filter(r -> r.offset() < partitionsOffsets.get(entry.getKey()))
+                  .collect(Collectors.toList());
+            Collections.reverse(partitionRecords);
+
+            log.info("{} records polled", records.count());
+            log.info("{} records sent", partitionRecords.size());
+            for (ConsumerRecord<Bytes, Bytes> msg : partitionRecords) {
+              if (!sink.isCancelled() && !waitingOffsets.beginReached()) {
+                sink.next(msg);
+                waitingOffsets.markPolled(msg);
+              } else {
+                log.info("Begin reached");
+                break;
+              }
+            }
+            partitionsOffsets.put(
+                entry.getKey(),
+                Math.max(offset, entry.getValue() - msgsPerPartition)
+            );
+          }
+          if (waitingOffsets.beginReached()) {
+            log.info("begin reached after partitions");
+          } else if (sink.isCancelled()) {
+            log.info("sink is cancelled after partitions");
+          }
+        }
+        sink.complete();
+        log.info("Polling finished");
+      }
+    } catch (Exception e) {
+      log.error("Error occurred while consuming records", e);
+      sink.error(e);
+    }
+  }
+}

--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/emitter/ForwardRecordEmitter.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/emitter/ForwardRecordEmitter.java
@@ -1,0 +1,49 @@
+package com.provectus.kafka.ui.emitter;
+
+import com.provectus.kafka.ui.util.OffsetsSeek;
+import java.time.Duration;
+import java.util.function.Supplier;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.utils.Bytes;
+import reactor.core.publisher.FluxSink;
+
+@RequiredArgsConstructor
+@Log4j2
+public class ForwardRecordEmitter
+    implements java.util.function.Consumer<FluxSink<ConsumerRecord<Bytes, Bytes>>> {
+
+  private static final Duration POLL_TIMEOUT_MS = Duration.ofMillis(1000L);
+
+  private final Supplier<KafkaConsumer<Bytes, Bytes>> consumerSupplier;
+  private final OffsetsSeek offsetsSeek;
+
+  @Override
+  public void accept(FluxSink<ConsumerRecord<Bytes, Bytes>> sink) {
+    try (KafkaConsumer<Bytes, Bytes> consumer = consumerSupplier.get()) {
+      var waitingOffsets = offsetsSeek.assignAndSeek(consumer);
+      while (!sink.isCancelled() && !waitingOffsets.endReached()) {
+        ConsumerRecords<Bytes, Bytes> records = consumer.poll(POLL_TIMEOUT_MS);
+        log.info("{} records polled", records.count());
+
+        for (ConsumerRecord<Bytes, Bytes> msg : records) {
+          if (!sink.isCancelled() && !waitingOffsets.endReached()) {
+            sink.next(msg);
+            waitingOffsets.markPolled(msg);
+          } else {
+            break;
+          }
+        }
+
+      }
+      sink.complete();
+      log.info("Polling finished");
+    } catch (Exception e) {
+      log.error("Error occurred while consuming records", e);
+      sink.error(e);
+    }
+  }
+}

--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/model/ConsumerPosition.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/model/ConsumerPosition.java
@@ -2,11 +2,11 @@ package com.provectus.kafka.ui.model;
 
 import java.util.Map;
 import lombok.Value;
+import org.apache.kafka.common.TopicPartition;
 
 @Value
 public class ConsumerPosition {
-
-  private SeekType seekType;
-  private Map<Integer, Long> seekTo;
-  private SeekDirection seekDirection;
+  SeekType seekType;
+  Map<TopicPartition, Long> seekTo;
+  SeekDirection seekDirection;
 }

--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/serde/schemaregistry/JsonMessageReader.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/serde/schemaregistry/JsonMessageReader.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
-import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import java.io.IOException;
 import lombok.SneakyThrows;

--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/serde/schemaregistry/MessageReader.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/serde/schemaregistry/MessageReader.java
@@ -3,7 +3,6 @@ package com.provectus.kafka.ui.serde.schemaregistry;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
-import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import java.io.IOException;
 import org.apache.kafka.common.serialization.Serializer;
@@ -12,8 +11,7 @@ public abstract class MessageReader<T> {
   protected final Serializer<T> serializer;
   protected final String topic;
   protected final boolean isKey;
-
-  private ParsedSchema schema;
+  private final ParsedSchema schema;
 
   protected MessageReader(String topic, boolean isKey, SchemaRegistryClient client,
                           SchemaMetadata schema) throws IOException, RestClientException {

--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/serde/schemaregistry/ProtobufMessageReader.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/serde/schemaregistry/ProtobufMessageReader.java
@@ -6,7 +6,6 @@ import com.google.protobuf.util.JsonFormat;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
-import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
 import io.confluent.kafka.serializers.protobuf.KafkaProtobufSerializer;

--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/util/jsonschema/EnumJsonType.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/util/jsonschema/EnumJsonType.java
@@ -7,7 +7,7 @@ import java.util.Map;
 
 
 public class EnumJsonType extends JsonType {
-  private List<String> values;
+  private final List<String> values;
 
   public EnumJsonType(List<String> values) {
     super(Type.ENUM);

--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/util/jsonschema/JsonSchema.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/util/jsonschema/JsonSchema.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;

--- a/kafka-ui-api/src/main/resources/application-sdp.yml
+++ b/kafka-ui-api/src/main/resources/application-sdp.yml
@@ -1,9 +1,9 @@
 kafka:
   clusters:
     - name: local
-      bootstrapServers: localhost:9093
-      zookeeper: localhost:2181
-      schemaRegistry: http://localhost:8083
+      bootstrapServers: b-1.kad-msk.uxahxx.c6.kafka.eu-west-1.amazonaws.com:9092
+#      zookeeper: localhost:2181
+#      schemaRegistry: http://localhost:8083
   #    -
   #      name: secondLocal
   #      zookeeper: zookeeper1:2181

--- a/kafka-ui-api/src/test/java/com/provectus/kafka/ui/AbstractBaseTest.java
+++ b/kafka-ui-api/src/test/java/com/provectus/kafka/ui/AbstractBaseTest.java
@@ -24,8 +24,8 @@ import org.testcontainers.utility.DockerImageName;
 @SpringBootTest
 @ActiveProfiles("test")
 public abstract class AbstractBaseTest {
-  public static String LOCAL = "local";
-  public static String SECOND_LOCAL = "secondLocal";
+  public static final String LOCAL = "local";
+  public static final String SECOND_LOCAL = "secondLocal";
 
   private static final String CONFLUENT_PLATFORM_VERSION = "5.5.0";
 

--- a/kafka-ui-api/src/test/java/com/provectus/kafka/ui/KafaConsumerGroupTests.java
+++ b/kafka-ui-api/src/test/java/com/provectus/kafka/ui/KafaConsumerGroupTests.java
@@ -20,7 +20,7 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 @ContextConfiguration(initializers = {AbstractBaseTest.Initializer.class})
 @Log4j2
 @AutoConfigureWebTestClient(timeout = "10000")
-public class KakfaConsumerGroupTests extends AbstractBaseTest {
+public class KafaConsumerGroupTests extends AbstractBaseTest {
   @Autowired
   WebTestClient webTestClient;
 

--- a/kafka-ui-api/src/test/java/com/provectus/kafka/ui/KafkaConsumerGroupTests.java
+++ b/kafka-ui-api/src/test/java/com/provectus/kafka/ui/KafkaConsumerGroupTests.java
@@ -20,7 +20,7 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 @ContextConfiguration(initializers = {AbstractBaseTest.Initializer.class})
 @Log4j2
 @AutoConfigureWebTestClient(timeout = "10000")
-public class KafaConsumerGroupTests extends AbstractBaseTest {
+public class KafkaConsumerGroupTests extends AbstractBaseTest {
   @Autowired
   WebTestClient webTestClient;
 

--- a/kafka-ui-api/src/test/java/com/provectus/kafka/ui/service/RecordEmitterTest.java
+++ b/kafka-ui-api/src/test/java/com/provectus/kafka/ui/service/RecordEmitterTest.java
@@ -1,27 +1,33 @@
 package com.provectus.kafka.ui.service;
 
-import static com.provectus.kafka.ui.service.ConsumingService.RecordEmitter;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.provectus.kafka.ui.AbstractBaseTest;
+import com.provectus.kafka.ui.emitter.BackwardRecordEmitter;
+import com.provectus.kafka.ui.emitter.ForwardRecordEmitter;
 import com.provectus.kafka.ui.model.ConsumerPosition;
 import com.provectus.kafka.ui.model.SeekDirection;
 import com.provectus.kafka.ui.model.SeekType;
 import com.provectus.kafka.ui.producer.KafkaTestProducer;
+import com.provectus.kafka.ui.util.OffsetsSeekBackward;
 import com.provectus.kafka.ui.util.OffsetsSeekForward;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 import lombok.Value;
+import lombok.extern.log4j.Log4j2;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.BytesDeserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.utils.Bytes;
@@ -30,6 +36,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 
+@Log4j2
 class RecordEmitterTest extends AbstractBaseTest {
 
   static final int PARTITIONS = 5;
@@ -50,7 +57,12 @@ class RecordEmitterTest extends AbstractBaseTest {
           var value = "msg_" + partition + "_" + i;
           var metadata =
               producer.send(new ProducerRecord<>(TOPIC, partition, ts, null, value)).get();
-          SENT_RECORDS.add(new Record(value, metadata.partition(), metadata.offset(), ts));
+          SENT_RECORDS.add(new Record(
+              value,
+              new TopicPartition(metadata.topic(), metadata.partition()),
+              metadata.offset(),
+              ts)
+          );
         }
       }
     }
@@ -64,31 +76,56 @@ class RecordEmitterTest extends AbstractBaseTest {
 
   @Test
   void pollNothingOnEmptyTopic() {
-    var emitter = new RecordEmitter(
+    var forwardEmitter = new ForwardRecordEmitter(
         this::createConsumer,
         new OffsetsSeekForward(EMPTY_TOPIC,
             new ConsumerPosition(SeekType.BEGINNING, Map.of(), SeekDirection.FORWARD)
         )
     );
 
-    Long polledValues = Flux.create(emitter)
+    var backwardEmitter = new BackwardRecordEmitter(
+        this::createConsumer,
+        new OffsetsSeekBackward(
+            EMPTY_TOPIC,
+            new ConsumerPosition(SeekType.BEGINNING, Map.of(), SeekDirection.BACKWARD),
+            100
+        )
+    );
+
+    Long polledValues = Flux.create(forwardEmitter)
         .limitRequest(100)
         .count()
         .block();
 
     assertThat(polledValues).isZero();
+
+    polledValues = Flux.create(backwardEmitter)
+        .limitRequest(100)
+        .count()
+        .block();
+
+    assertThat(polledValues).isZero();
+
   }
 
   @Test
   void pollFullTopicFromBeginning() {
-    var emitter = new RecordEmitter(
+    var forwardEmitter = new ForwardRecordEmitter(
         this::createConsumer,
         new OffsetsSeekForward(TOPIC,
             new ConsumerPosition(SeekType.BEGINNING, Map.of(), SeekDirection.FORWARD)
         )
     );
 
-    var polledValues = Flux.create(emitter)
+    var backwardEmitter = new BackwardRecordEmitter(
+        this::createConsumer,
+        new OffsetsSeekBackward(TOPIC,
+            new ConsumerPosition(SeekType.BEGINNING, Map.of(), SeekDirection.FORWARD),
+            PARTITIONS * MSGS_PER_PARTITION
+        )
+    );
+
+    var polledValues = Flux.create(forwardEmitter)
         .map(this::deserialize)
         .limitRequest(Long.MAX_VALUE)
         .collect(Collectors.toList())
@@ -96,76 +133,198 @@ class RecordEmitterTest extends AbstractBaseTest {
 
     assertThat(polledValues).containsExactlyInAnyOrderElementsOf(
         SENT_RECORDS.stream().map(Record::getValue).collect(Collectors.toList()));
+
+    polledValues = Flux.create(backwardEmitter)
+        .map(this::deserialize)
+        .limitRequest(Long.MAX_VALUE)
+        .collect(Collectors.toList())
+        .block();
+
+    assertThat(polledValues).containsExactlyInAnyOrderElementsOf(
+        SENT_RECORDS.stream().map(Record::getValue).collect(Collectors.toList()));
+
   }
 
   @Test
   void pollWithOffsets() {
-    Map<Integer, Long> targetOffsets = new HashMap<>();
+    Map<TopicPartition, Long> targetOffsets = new HashMap<>();
     for (int i = 0; i < PARTITIONS; i++) {
       long offset = ThreadLocalRandom.current().nextLong(MSGS_PER_PARTITION);
-      targetOffsets.put(i, offset);
+      targetOffsets.put(new TopicPartition(TOPIC, i), offset);
     }
 
-    var emitter = new RecordEmitter(
+    var forwardEmitter = new ForwardRecordEmitter(
         this::createConsumer,
         new OffsetsSeekForward(TOPIC,
             new ConsumerPosition(SeekType.OFFSET, targetOffsets, SeekDirection.FORWARD)
         )
     );
 
-    var polledValues = Flux.create(emitter)
+    var backwardEmitter = new BackwardRecordEmitter(
+        this::createConsumer,
+        new OffsetsSeekBackward(TOPIC,
+            new ConsumerPosition(SeekType.OFFSET, targetOffsets, SeekDirection.BACKWARD),
+            PARTITIONS * MSGS_PER_PARTITION
+        )
+    );
+
+    var polledValues = Flux.create(forwardEmitter)
         .map(this::deserialize)
         .limitRequest(Long.MAX_VALUE)
         .collect(Collectors.toList())
         .block();
 
     var expectedValues = SENT_RECORDS.stream()
-        .filter(r -> r.getOffset() >= targetOffsets.get(r.getPartition()))
+        .filter(r -> r.getOffset() >= targetOffsets.get(r.getTp()))
         .map(Record::getValue)
         .collect(Collectors.toList());
+
+    assertThat(polledValues).containsExactlyInAnyOrderElementsOf(expectedValues);
+
+    expectedValues = SENT_RECORDS.stream()
+        .filter(r -> r.getOffset() < targetOffsets.get(r.getTp()))
+        .map(Record::getValue)
+        .collect(Collectors.toList());
+
+    polledValues =  Flux.create(backwardEmitter)
+        .map(this::deserialize)
+        .limitRequest(Long.MAX_VALUE)
+        .collect(Collectors.toList())
+        .block();
 
     assertThat(polledValues).containsExactlyInAnyOrderElementsOf(expectedValues);
   }
 
   @Test
   void pollWithTimestamps() {
-    Map<Integer, Long> targetTimestamps = new HashMap<>();
+    Map<TopicPartition, Long> targetTimestamps = new HashMap<>();
+    final Map<TopicPartition, List<Record>> perPartition =
+        SENT_RECORDS.stream().collect(Collectors.groupingBy((r) -> r.tp));
     for (int i = 0; i < PARTITIONS; i++) {
-      int randRecordIdx = ThreadLocalRandom.current().nextInt(SENT_RECORDS.size());
-      targetTimestamps.put(i, SENT_RECORDS.get(randRecordIdx).getTimestamp());
+      final List<Record> records = perPartition.get(new TopicPartition(TOPIC, i));
+      int randRecordIdx = ThreadLocalRandom.current().nextInt(records.size());
+      log.info("partition: {} position: {}", i, randRecordIdx);
+      targetTimestamps.put(
+          new TopicPartition(TOPIC, i),
+          records.get(randRecordIdx).getTimestamp()
+      );
     }
 
-    var emitter = new RecordEmitter(
+    var forwardEmitter = new ForwardRecordEmitter(
         this::createConsumer,
         new OffsetsSeekForward(TOPIC,
             new ConsumerPosition(SeekType.TIMESTAMP, targetTimestamps, SeekDirection.FORWARD)
         )
     );
 
-    var polledValues = Flux.create(emitter)
+    var backwardEmitter = new BackwardRecordEmitter(
+        this::createConsumer,
+        new OffsetsSeekBackward(TOPIC,
+            new ConsumerPosition(SeekType.TIMESTAMP, targetTimestamps, SeekDirection.BACKWARD),
+            PARTITIONS * MSGS_PER_PARTITION
+        )
+    );
+
+    var polledValues = Flux.create(forwardEmitter)
         .map(this::deserialize)
         .limitRequest(Long.MAX_VALUE)
         .collect(Collectors.toList())
         .block();
 
     var expectedValues = SENT_RECORDS.stream()
-        .filter(r -> r.getTimestamp() >= targetTimestamps.get(r.getPartition()))
+        .filter(r -> r.getTimestamp() >= targetTimestamps.get(r.getTp()))
         .map(Record::getValue)
         .collect(Collectors.toList());
 
     assertThat(polledValues).containsExactlyInAnyOrderElementsOf(expectedValues);
+
+    polledValues = Flux.create(backwardEmitter)
+        .map(this::deserialize)
+        .limitRequest(Long.MAX_VALUE)
+        .collect(Collectors.toList())
+        .block();
+
+    expectedValues = SENT_RECORDS.stream()
+        .filter(r -> r.getTimestamp() < targetTimestamps.get(r.getTp()))
+        .map(Record::getValue)
+        .collect(Collectors.toList());
+
+    assertThat(polledValues).containsExactlyInAnyOrderElementsOf(expectedValues);
+
+  }
+
+  @Test
+  void backwardEmitterSeekToEnd() {
+    final int numMessages = 100;
+    final Map<TopicPartition, Long> targetOffsets = new HashMap<>();
+    for (int i = 0; i < PARTITIONS; i++) {
+      targetOffsets.put(new TopicPartition(TOPIC, i), (long) MSGS_PER_PARTITION);
+    }
+
+    var backwardEmitter = new BackwardRecordEmitter(
+        this::createConsumer,
+        new OffsetsSeekBackward(TOPIC,
+            new ConsumerPosition(SeekType.OFFSET, targetOffsets, SeekDirection.BACKWARD),
+            numMessages
+        )
+    );
+
+    var polledValues = Flux.create(backwardEmitter)
+        .map(this::deserialize)
+        .limitRequest(numMessages)
+        .collect(Collectors.toList())
+        .block();
+
+    var expectedValues = SENT_RECORDS.stream()
+        .filter(r -> r.getOffset() < targetOffsets.get(r.getTp()))
+        .filter(r -> r.getOffset() >= (targetOffsets.get(r.getTp()) - (100 / PARTITIONS)))
+        .map(Record::getValue)
+        .collect(Collectors.toList());
+
+
+    assertThat(polledValues).containsExactlyInAnyOrderElementsOf(expectedValues);
+  }
+
+  @Test
+  void backwardEmitterSeekToBegin() {
+    Map<TopicPartition, Long> offsets = new HashMap<>();
+    for (int i = 0; i < PARTITIONS; i++) {
+      offsets.put(new TopicPartition(TOPIC, i), 0L);
+    }
+
+    var backwardEmitter = new BackwardRecordEmitter(
+        this::createConsumer,
+        new OffsetsSeekBackward(TOPIC,
+            new ConsumerPosition(SeekType.OFFSET, offsets, SeekDirection.BACKWARD),
+            100
+        )
+    );
+
+    var polledValues = Flux.create(backwardEmitter)
+        .map(this::deserialize)
+        .limitRequest(Long.MAX_VALUE)
+        .collect(Collectors.toList())
+        .block();
+
+    assertThat(polledValues).isEmpty();
   }
 
   private KafkaConsumer<Bytes, Bytes> createConsumer() {
-    return new KafkaConsumer<>(
-        Map.of(
-            ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafka.getBootstrapServers(),
-            ConsumerConfig.GROUP_ID_CONFIG, UUID.randomUUID().toString(),
-            ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 20, // to check multiple polls
-            ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, BytesDeserializer.class,
-            ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, BytesDeserializer.class
-        )
+    return createConsumer(Map.of());
+  }
+
+  private KafkaConsumer<Bytes, Bytes> createConsumer(Map<String, Object> properties) {
+    final Map<String, ? extends Serializable> map = Map.of(
+        ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafka.getBootstrapServers(),
+        ConsumerConfig.GROUP_ID_CONFIG, UUID.randomUUID().toString(),
+        ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 20, // to check multiple polls
+        ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, BytesDeserializer.class,
+        ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, BytesDeserializer.class
     );
+    Properties props = new Properties();
+    props.putAll(map);
+    props.putAll(properties);
+    return new KafkaConsumer<>(props);
   }
 
   private String deserialize(ConsumerRecord<Bytes, Bytes> rec) {
@@ -175,7 +334,7 @@ class RecordEmitterTest extends AbstractBaseTest {
   @Value
   static class Record {
     String value;
-    int partition;
+    TopicPartition tp;
     long offset;
     long timestamp;
   }


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing applications:)
<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)

**Is there anything you'd like reviewers to focus on?**


**How Has This Been Tested?** (put an "X" next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [X] Manually(please, describe, when necessary)
- [X] Unit checks
- [X] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "X" next to an item, otherwise PR will fail)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [X] My changes generate no new warnings(e.g. Sonar is happy)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged

Check out [Contributing](https://github.com/provectus/kafka-ui/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/provectus/kafka-ui/blob/master/CODE-OF-CONDUCT.md)