### PR TITLE
Fix sending messages form

### DIFF
--- a/kafka-ui-react-app/src/components/Topics/Topic/SendMessage/SendMessage.tsx
+++ b/kafka-ui-react-app/src/components/Topics/Topic/SendMessage/SendMessage.tsx
@@ -43,6 +43,7 @@ const SendMessage: React.FC<Props> = ({
 }) => {
   const [keyExampleValue, setKeyExampleValue] = React.useState('');
   const [contentExampleValue, setContentExampleValue] = React.useState('');
+  const [schemaIsReady, setSchemaIsReady] = React.useState(false);
   const [schemaErrorString, setSchemaErrorString] = React.useState('');
   const {
     register,
@@ -62,6 +63,7 @@ const SendMessage: React.FC<Props> = ({
         setKeyExampleValue(
           JSON.stringify(getFakeData(validateKey), null, '\t')
         );
+        setSchemaIsReady(true);
       }
 
       const validateContent = convertToYup(
@@ -71,6 +73,11 @@ const SendMessage: React.FC<Props> = ({
         setContentExampleValue(
           JSON.stringify(getFakeData(validateContent), null, '\t')
         );
+        setSchemaIsReady(true);
+      }
+
+      if (!validateKey && !validateContent) {
+        setSchemaIsReady(true);
       }
     }
   }, [schemaIsFetched]);
@@ -109,7 +116,7 @@ const SendMessage: React.FC<Props> = ({
     }
   };
 
-  if (!keyExampleValue && !contentExampleValue) {
+  if (!schemaIsReady) {
     return <PageLoader />;
   }
   return (


### PR DESCRIPTION
After manually testing the message sending form, I noticed a bug that happens when either key or value of the message schema has a type other than `object`, for example, `string`: 
```json
{
   "key":{
      "name":"unknown",
      "source":"SOURCE_SCHEMA_REGISTRY",
      "schema":"{\"$id\":\"http://unknown.unknown\",\"$schema\":\"https://json-schema.org/draft/2020-12/schema\",\"type\":\"string\"}"
   },
}
```
Turns out that the json-schema-to-yup-transformer can handle only `objects` as the base type. The same applies to other json schema to yup converters. Some return `undefined`, others throw an error. I added a small fix, so that the message sending form doesn't become an infinite page loader when both key and message are not object, but it is a temporal fix because no validation happens in this case. 
Right now I don't know what to do with this problem, so it might be worth creating a separate issue for it.