### PR TITLE
Revert "Bump react-hook-form from 7.6.9 to 7.12.2 in /kafka-ui-react-app"

### DIFF
--- a/kafka-ui-react-app/package-lock.json
+++ b/kafka-ui-react-app/package-lock.json
@@ -16600,9 +16600,9 @@
       "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
     },
     "react-hook-form": {
-      "version": "7.12.2",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.12.2.tgz",
-      "integrity": "sha512-cpxocjrgpMAJCMJQR51BQhMoEx80/EQqePNihMTgoTYTqCRbd2GExi+N4GJIr+cFqrmbwNj9wxk5oLWYQsUefg=="
+      "version": "7.6.9",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.6.9.tgz",
+      "integrity": "sha512-nz+btC4WFIm3zPBjw22K3t9nnJtlMMwj8slcbPYoTKlkSVA5l+q3Ai+VF0YzeRi7vbyyeGQvpyibov1xd/TV7A=="
     },
     "react-is": {
       "version": "16.13.1",

--- a/kafka-ui-react-app/package.json
+++ b/kafka-ui-react-app/package.json
@@ -26,7 +26,7 @@
     "react-ace": "^9.4.3",
     "react-datepicker": "^4.2.0",
     "react-dom": "^17.0.1",
-    "react-hook-form": "7.12.2",
+    "react-hook-form": "7.6.9",
     "react-json-tree": "^0.15.0",
     "react-multi-select-component": "^4.0.6",
     "react-redux": "^7.2.2",


### PR DESCRIPTION
Reverts provectus/kafka-ui#760