### PR TITLE
KSQL: fixed ShowStatement behaviour for parallel requests

### DIFF
--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/strategy/ksql/statement/ShowStrategy.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/strategy/ksql/statement/ShowStrategy.java
@@ -1,6 +1,7 @@
 package com.provectus.kafka.ui.strategy.ksql.statement;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.provectus.kafka.ui.model.KsqlCommand;
 import com.provectus.kafka.ui.model.KsqlCommandResponse;
 import java.util.List;
 import java.util.Optional;
@@ -34,6 +35,15 @@ public class ShowStrategy extends BaseStrategy {
   @Override
   protected String getTestRegExp() {
     return "";
+  }
+
+  @Override
+  public BaseStrategy ksqlCommand(KsqlCommand ksqlCommand) {
+    // return new instance to avoid conflicts for parallel requests
+    ShowStrategy clone = new ShowStrategy();
+    clone.setResponseValueKey(responseValueKey);
+    clone.ksqlCommand = ksqlCommand;
+    return clone;
   }
 
   protected String getShowRegExp(String key) {


### PR DESCRIPTION
## Issue: #207

### Done:
 - fixed issue with parallel ksql requests for ShowStrategy. ShowStrategy has property `responseValueKey` which required for response mapping. Parallel requests were rewriting this property. Fix returns new instance of ShowStrategy.