### PR TITLE
Fix the redirect after topic deletion

### DIFF
--- a/kafka-ui-react-app/src/components/Topics/Topic/Details/Details.tsx
+++ b/kafka-ui-react-app/src/components/Topics/Topic/Details/Details.tsx
@@ -23,6 +23,7 @@ interface Props extends Topic, TopicDetails {
   clusterName: ClusterName;
   topicName: TopicName;
   isInternal: boolean;
+  isDeleted: boolean;
   deleteTopic: (clusterName: ClusterName, topicName: TopicName) => void;
   clearTopicMessages(clusterName: ClusterName, topicName: TopicName): void;
 }
@@ -31,6 +32,7 @@ const Details: React.FC<Props> = ({
   clusterName,
   topicName,
   isInternal,
+  isDeleted,
   deleteTopic,
   clearTopicMessages,
 }) => {
@@ -41,8 +43,12 @@ const Details: React.FC<Props> = ({
     React.useState(false);
   const deleteTopicHandler = React.useCallback(() => {
     deleteTopic(clusterName, topicName);
-    history.push(clusterTopicsPath(clusterName));
   }, [clusterName, topicName]);
+  React.useEffect(() => {
+    if (isDeleted) {
+      history.push(clusterTopicsPath(clusterName));
+    }
+  }, [isDeleted]);
 
   const clearTopicMessagesHandler = React.useCallback(() => {
     clearTopicMessages(clusterName, topicName);

--- a/kafka-ui-react-app/src/components/Topics/Topic/Details/DetailsContainer.ts
+++ b/kafka-ui-react-app/src/components/Topics/Topic/Details/DetailsContainer.ts
@@ -2,7 +2,10 @@ import { connect } from 'react-redux';
 import { ClusterName, RootState, TopicName } from 'redux/interfaces';
 import { withRouter, RouteComponentProps } from 'react-router-dom';
 import { deleteTopic, clearTopicMessages } from 'redux/actions';
-import { getIsTopicInternal } from 'redux/reducers/topics/selectors';
+import {
+  getIsTopicInternal,
+  getIsTopicDeleted,
+} from 'redux/reducers/topics/selectors';
 
 import Details from './Details';
 
@@ -24,6 +27,7 @@ const mapStateToProps = (
   clusterName,
   topicName,
   isInternal: getIsTopicInternal(state, topicName),
+  isDeleted: getIsTopicDeleted(state),
 });
 
 const mapDispatchToProps = {

--- a/kafka-ui-react-app/src/components/Topics/Topic/Details/__test__/Details.spec.tsx
+++ b/kafka-ui-react-app/src/components/Topics/Topic/Details/__test__/Details.spec.tsx
@@ -39,6 +39,7 @@ describe('Details', () => {
                 isInternal={mockInternalTopicPayload}
                 deleteTopic={mockDelete}
                 clearTopicMessages={mockClearTopicMessages}
+                isDeleted={false}
               />
             </ClusterContext.Provider>
           </StaticRouter>
@@ -69,6 +70,7 @@ describe('Details', () => {
                 isInternal={mockExternalTopicPayload}
                 deleteTopic={mockDelete}
                 clearTopicMessages={mockClearTopicMessages}
+                isDeleted={false}
               />
             </ClusterContext.Provider>
           </StaticRouter>

--- a/kafka-ui-react-app/src/redux/reducers/topics/selectors.ts
+++ b/kafka-ui-react-app/src/redux/reducers/topics/selectors.ts
@@ -31,6 +31,12 @@ const getPartitionsCountIncreaseStatus =
 const getReplicationFactorUpdateStatus = createFetchingSelector(
   'UPDATE_REPLICATION_FACTOR'
 );
+const getTopicDeletingStatus = createFetchingSelector('DELETE_TOPIC');
+
+export const getIsTopicDeleted = createSelector(
+  getTopicDeletingStatus,
+  (status) => status === 'fetched'
+);
 
 export const getAreTopicsFetching = createSelector(
   getTopicListFetchingStatus,


### PR DESCRIPTION
Before the redirect was right after the deletion action was fired, now it is done only after the confirmation from the backend