### PR TITLE
Clear topic messages locally

### DIFF
--- a/kafka-ui-react-app/src/redux/reducers/topicMessages/reducer.ts
+++ b/kafka-ui-react-app/src/redux/reducers/topicMessages/reducer.ts
@@ -38,6 +38,11 @@ const reducer = (state = initialState, action: Action): TopicMessagesState => {
         ...state,
         isFetching: action.payload,
       };
+    case getType(actions.clearMessagesTopicAction.success):
+      return {
+        ...state,
+        messages: [],
+      };
     default:
       return state;
   }


### PR DESCRIPTION
After sending a request for clearing the topic messages, nothing happened locally, a user had to reload the page to see the results. Now the messages are cleared from the store after a successful request