### PR TITLE
Redirect right after a message is sent

### DIFF
--- a/kafka-ui-react-app/src/components/Topics/Topic/SendMessage/SendMessage.tsx
+++ b/kafka-ui-react-app/src/components/Topics/Topic/SendMessage/SendMessage.tsx
@@ -25,7 +25,6 @@ export interface Props {
   ) => void;
   messageSchema: TopicMessageSchema | undefined;
   schemaIsFetched: boolean;
-  messageIsSent: boolean;
   messageIsSending: boolean;
   partitions: Partition[];
 }
@@ -37,7 +36,6 @@ const SendMessage: React.FC<Props> = ({
   sendTopicMessage,
   messageSchema,
   schemaIsFetched,
-  messageIsSent,
   messageIsSending,
   partitions,
 }) => {
@@ -81,11 +79,6 @@ const SendMessage: React.FC<Props> = ({
       }
     }
   }, [schemaIsFetched]);
-  React.useEffect(() => {
-    if (messageIsSent) {
-      history.push(clusterTopicMessagesPath(clusterName, topicName));
-    }
-  }, [messageIsSent]);
 
   const onSubmit = async (data: {
     key: string;
@@ -112,6 +105,7 @@ const SendMessage: React.FC<Props> = ({
           headers,
           partition,
         });
+        history.push(clusterTopicMessagesPath(clusterName, topicName));
       }
     }
   };

--- a/kafka-ui-react-app/src/components/Topics/Topic/SendMessage/SendMessageContainer.ts
+++ b/kafka-ui-react-app/src/components/Topics/Topic/SendMessage/SendMessageContainer.ts
@@ -7,7 +7,6 @@ import {
   getPartitionsByTopicName,
   getTopicMessageSchemaFetched,
   getTopicMessageSending,
-  getTopicMessageSent,
 } from 'redux/reducers/topics/selectors';
 
 import SendMessage from './SendMessage';
@@ -31,7 +30,6 @@ const mapStateToProps = (
   topicName,
   messageSchema: getMessageSchemaByTopicName(state, topicName),
   schemaIsFetched: getTopicMessageSchemaFetched(state),
-  messageIsSent: getTopicMessageSent(state),
   messageIsSending: getTopicMessageSending(state),
   partitions: getPartitionsByTopicName(state, topicName),
 });

--- a/kafka-ui-react-app/src/components/Topics/Topic/SendMessage/__test__/SendMessage.spec.tsx
+++ b/kafka-ui-react-app/src/components/Topics/Topic/SendMessage/__test__/SendMessage.spec.tsx
@@ -72,7 +72,6 @@ const setupWrapper = (props?: Partial<Props>) => (
       },
     }}
     schemaIsFetched={false}
-    messageIsSent={false}
     messageIsSending={false}
     partitions={[
       {

--- a/kafka-ui-react-app/src/redux/reducers/topics/selectors.ts
+++ b/kafka-ui-react-app/src/redux/reducers/topics/selectors.ts
@@ -72,11 +72,6 @@ export const getTopicMessageSchemaFetched = createSelector(
   (status) => status === 'fetched'
 );
 
-export const getTopicMessageSent = createSelector(
-  getTopicMessageSendingStatus,
-  (status) => status === 'fetched'
-);
-
 export const getTopicMessageSending = createSelector(
   getTopicMessageSendingStatus,
   (status) => status === 'fetching'


### PR DESCRIPTION
Since I used the redux loader to detect if the message was sent and we can redirect to another page, it led to a bug when we cannot go to the message sending page after the message was already sent - it was simply redirected immediately. I removed this part of redux entirely and redirect right after the form was submitted. This is not a perfect solution, since we do not wait for the backend response and it can lead to a race condition of some kind, but I see no other solution for now. 
I believe, we need some mechanism for manual resetting of redux loaders.