### PR TITLE
Fix redirect after the topic deletion

### DIFF
--- a/kafka-ui-react-app/src/components/Topics/Topic/Details/Details.tsx
+++ b/kafka-ui-react-app/src/components/Topics/Topic/Details/Details.tsx
@@ -26,7 +26,6 @@ interface Props extends Topic, TopicDetails {
   topicName: TopicName;
   isInternal: boolean;
   isDeleted: boolean;
-  fetchTopicsList: (params: GetTopicsRequest) => void;
   deleteTopic: (clusterName: ClusterName, topicName: TopicName) => void;
   clearTopicMessages(clusterName: ClusterName, topicName: TopicName): void;
 }
@@ -36,14 +35,9 @@ const Details: React.FC<Props> = ({
   topicName,
   isInternal,
   isDeleted,
-  fetchTopicsList,
   deleteTopic,
   clearTopicMessages,
 }) => {
-  React.useEffect(() => {
-    fetchTopicsList({ clusterName });
-  }, []);
-
   const history = useHistory();
   const dispatch = useDispatch();
   const { isReadOnly, isTopicDeletionAllowed } =

--- a/kafka-ui-react-app/src/components/Topics/Topic/Details/Details.tsx
+++ b/kafka-ui-react-app/src/components/Topics/Topic/Details/Details.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ClusterName, TopicName } from 'redux/interfaces';
-import { Topic, TopicDetails } from 'generated-sources';
+import { GetTopicsRequest, Topic, TopicDetails } from 'generated-sources';
 import { NavLink, Switch, Route, Link, useHistory } from 'react-router-dom';
 import {
   clusterTopicSettingsPath,
@@ -13,6 +13,8 @@ import {
 } from 'lib/paths';
 import ClusterContext from 'components/contexts/ClusterContext';
 import ConfirmationModal from 'components/common/ConfirmationModal/ConfirmationModal';
+import { useDispatch } from 'react-redux';
+import { deleteTopicAction } from 'redux/actions';
 
 import OverviewContainer from './Overview/OverviewContainer';
 import TopicConsumerGroupsContainer from './ConsumerGroups/TopicConsumerGroupsContainer';
@@ -24,6 +26,7 @@ interface Props extends Topic, TopicDetails {
   topicName: TopicName;
   isInternal: boolean;
   isDeleted: boolean;
+  fetchTopicsList: (params: GetTopicsRequest) => void;
   deleteTopic: (clusterName: ClusterName, topicName: TopicName) => void;
   clearTopicMessages(clusterName: ClusterName, topicName: TopicName): void;
 }
@@ -33,10 +36,16 @@ const Details: React.FC<Props> = ({
   topicName,
   isInternal,
   isDeleted,
+  fetchTopicsList,
   deleteTopic,
   clearTopicMessages,
 }) => {
+  React.useEffect(() => {
+    fetchTopicsList({ clusterName });
+  }, []);
+
   const history = useHistory();
+  const dispatch = useDispatch();
   const { isReadOnly, isTopicDeletionAllowed } =
     React.useContext(ClusterContext);
   const [isDeleteTopicConfirmationVisible, setDeleteTopicConfirmationVisible] =
@@ -44,8 +53,10 @@ const Details: React.FC<Props> = ({
   const deleteTopicHandler = React.useCallback(() => {
     deleteTopic(clusterName, topicName);
   }, [clusterName, topicName]);
+
   React.useEffect(() => {
     if (isDeleted) {
+      dispatch(deleteTopicAction.cancel());
       history.push(clusterTopicsPath(clusterName));
     }
   }, [isDeleted]);

--- a/kafka-ui-react-app/src/components/Topics/Topic/Details/Details.tsx
+++ b/kafka-ui-react-app/src/components/Topics/Topic/Details/Details.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ClusterName, TopicName } from 'redux/interfaces';
-import { GetTopicsRequest, Topic, TopicDetails } from 'generated-sources';
+import { Topic, TopicDetails } from 'generated-sources';
 import { NavLink, Switch, Route, Link, useHistory } from 'react-router-dom';
 import {
   clusterTopicSettingsPath,

--- a/kafka-ui-react-app/src/components/Topics/Topic/Details/DetailsContainer.ts
+++ b/kafka-ui-react-app/src/components/Topics/Topic/Details/DetailsContainer.ts
@@ -1,11 +1,7 @@
 import { connect } from 'react-redux';
 import { ClusterName, RootState, TopicName } from 'redux/interfaces';
 import { withRouter, RouteComponentProps } from 'react-router-dom';
-import {
-  deleteTopic,
-  clearTopicMessages,
-  fetchTopicsList,
-} from 'redux/actions';
+import { deleteTopic, clearTopicMessages } from 'redux/actions';
 import {
   getIsTopicDeleted,
   getIsTopicInternal,
@@ -37,7 +33,6 @@ const mapStateToProps = (
 const mapDispatchToProps = {
   deleteTopic,
   clearTopicMessages,
-  fetchTopicsList,
 };
 
 export default withRouter(

--- a/kafka-ui-react-app/src/components/Topics/Topic/Details/DetailsContainer.ts
+++ b/kafka-ui-react-app/src/components/Topics/Topic/Details/DetailsContainer.ts
@@ -1,10 +1,14 @@
 import { connect } from 'react-redux';
 import { ClusterName, RootState, TopicName } from 'redux/interfaces';
 import { withRouter, RouteComponentProps } from 'react-router-dom';
-import { deleteTopic, clearTopicMessages } from 'redux/actions';
 import {
+  deleteTopic,
+  clearTopicMessages,
+  fetchTopicsList,
+} from 'redux/actions';
+import {
+  getIsTopicDeleted,
   getIsTopicInternal,
-  getTopicList,
 } from 'redux/reducers/topics/selectors';
 
 import Details from './Details';
@@ -27,12 +31,13 @@ const mapStateToProps = (
   clusterName,
   topicName,
   isInternal: getIsTopicInternal(state, topicName),
-  isDeleted: !getTopicList(state).find((topic) => topic.name === topicName),
+  isDeleted: getIsTopicDeleted(state),
 });
 
 const mapDispatchToProps = {
   deleteTopic,
   clearTopicMessages,
+  fetchTopicsList,
 };
 
 export default withRouter(

--- a/kafka-ui-react-app/src/components/Topics/Topic/Details/__test__/Details.spec.tsx
+++ b/kafka-ui-react-app/src/components/Topics/Topic/Details/__test__/Details.spec.tsx
@@ -39,7 +39,6 @@ describe('Details', () => {
                 isInternal={mockInternalTopicPayload}
                 deleteTopic={mockDelete}
                 clearTopicMessages={mockClearTopicMessages}
-                fetchTopicsList={jest.fn()}
                 isDeleted={false}
               />
             </ClusterContext.Provider>
@@ -71,7 +70,6 @@ describe('Details', () => {
                 isInternal={mockExternalTopicPayload}
                 deleteTopic={mockDelete}
                 clearTopicMessages={mockClearTopicMessages}
-                fetchTopicsList={jest.fn()}
                 isDeleted={false}
               />
             </ClusterContext.Provider>

--- a/kafka-ui-react-app/src/components/Topics/Topic/Details/__test__/Details.spec.tsx
+++ b/kafka-ui-react-app/src/components/Topics/Topic/Details/__test__/Details.spec.tsx
@@ -39,6 +39,7 @@ describe('Details', () => {
                 isInternal={mockInternalTopicPayload}
                 deleteTopic={mockDelete}
                 clearTopicMessages={mockClearTopicMessages}
+                fetchTopicsList={jest.fn()}
                 isDeleted={false}
               />
             </ClusterContext.Provider>
@@ -70,6 +71,7 @@ describe('Details', () => {
                 isInternal={mockExternalTopicPayload}
                 deleteTopic={mockDelete}
                 clearTopicMessages={mockClearTopicMessages}
+                fetchTopicsList={jest.fn()}
                 isDeleted={false}
               />
             </ClusterContext.Provider>

--- a/kafka-ui-react-app/src/redux/actions/actions.ts
+++ b/kafka-ui-react-app/src/redux/actions/actions.ts
@@ -97,8 +97,9 @@ export const updateTopicAction = createAsyncAction(
 export const deleteTopicAction = createAsyncAction(
   'DELETE_TOPIC__REQUEST',
   'DELETE_TOPIC__SUCCESS',
-  'DELETE_TOPIC__FAILURE'
-)<undefined, TopicName, undefined>();
+  'DELETE_TOPIC__FAILURE',
+  'DELETE_TOPIC__CANCEL'
+)<undefined, TopicName, undefined, undefined>();
 
 export const fetchConsumerGroupsAction = createAsyncAction(
   'GET_CONSUMER_GROUPS__REQUEST',

--- a/kafka-ui-react-app/src/redux/reducers/loader/reducer.ts
+++ b/kafka-ui-react-app/src/redux/reducers/loader/reducer.ts
@@ -4,9 +4,9 @@ export const initialState: LoaderState = {};
 
 const reducer = (state = initialState, action: Action): LoaderState => {
   const { type } = action;
-  const matches = /(.*)__(REQUEST|SUCCESS|FAILURE)$/.exec(type);
+  const matches = /(.*)__(REQUEST|SUCCESS|FAILURE|CANCEL)$/.exec(type);
 
-  // not a *__REQUEST / *__SUCCESS /  *__FAILURE actions, so we ignore them
+  // not a *__REQUEST / *__SUCCESS /  *__FAILURE /  *__CANCEL actions, so we ignore them
   if (!matches) return state;
 
   const [, requestName, requestState] = matches;
@@ -26,6 +26,11 @@ const reducer = (state = initialState, action: Action): LoaderState => {
       return {
         ...state,
         [requestName]: 'errorFetching',
+      };
+    case 'CANCEL':
+      return {
+        ...state,
+        [requestName]: 'notFetched',
       };
     default:
       return state;

--- a/kafka-ui-react-app/src/redux/reducers/topics/selectors.ts
+++ b/kafka-ui-react-app/src/redux/reducers/topics/selectors.ts
@@ -31,6 +31,12 @@ const getPartitionsCountIncreaseStatus =
 const getReplicationFactorUpdateStatus = createFetchingSelector(
   'UPDATE_REPLICATION_FACTOR'
 );
+const getTopicDeletingStatus = createFetchingSelector('DELETE_TOPIC');
+
+export const getIsTopicDeleted = createSelector(
+  getTopicDeletingStatus,
+  (status) => status === 'fetched'
+);
 
 export const getAreTopicsFetching = createSelector(
   getTopicListFetchingStatus,


### PR DESCRIPTION
Turns out that the previous solution was faulty. It required the list of topics to be in the store in order to search through it. But when we accessed the topic details page from a direct link, it was not fetched. 

Fetching this list inside the details component didn't help, cause the hook that is responsible for the redirect after deletion was running before the response from the topics list fetching was coming. And keeping track of the number of component re-renders felt like a костыль and is kinda ugly.

So added a way to manually reset the value of the loader state.