### PR TITLE
ISSUE-849: Use a map between topics and message-names when using ProtobufFile

### DIFF
--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/config/ClustersProperties.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/config/ClustersProperties.java
@@ -26,7 +26,8 @@ public class ClustersProperties {
     String schemaNameTemplate = "%s-value";
     String keySchemaNameTemplate = "%s-key";
     String protobufFile;
-    Map<String, String> protobufMessageName;
+    String protobufMessageName;
+    Map<String, String> protobufMessageNameByTopic;
     List<ConnectCluster> kafkaConnect;
     int jmxPort;
     boolean jmxSsl;

--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/config/ClustersProperties.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/config/ClustersProperties.java
@@ -2,6 +2,7 @@ package com.provectus.kafka.ui.config;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -25,7 +26,7 @@ public class ClustersProperties {
     String schemaNameTemplate = "%s-value";
     String keySchemaNameTemplate = "%s-key";
     String protobufFile;
-    String protobufMessageName;
+    Map<String,String> protobufMessageName;
     List<ConnectCluster> kafkaConnect;
     int jmxPort;
     boolean jmxSsl;

--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/config/ClustersProperties.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/config/ClustersProperties.java
@@ -26,7 +26,7 @@ public class ClustersProperties {
     String schemaNameTemplate = "%s-value";
     String keySchemaNameTemplate = "%s-key";
     String protobufFile;
-    Map<String,String> protobufMessageName;
+    Map<String, String> protobufMessageName;
     List<ConnectCluster> kafkaConnect;
     int jmxPort;
     boolean jmxSsl;

--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/model/KafkaCluster.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/model/KafkaCluster.java
@@ -34,7 +34,8 @@ public class KafkaCluster {
   private final Throwable lastKafkaException;
   private final Throwable lastZookeeperException;
   private final Path protobufFile;
-  private final Map<String, String> protobufMessageName;
+  private final String protobufMessageName;
+  private final Map<String, String> protobufMessageNameByTopic;
   private final Properties properties;
   private final Boolean readOnly;
   private final Boolean disableLogDirsCollection;

--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/model/KafkaCluster.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/model/KafkaCluster.java
@@ -34,7 +34,7 @@ public class KafkaCluster {
   private final Throwable lastKafkaException;
   private final Throwable lastZookeeperException;
   private final Path protobufFile;
-  private final String protobufMessageName;
+  private final Map<String,String> protobufMessageName;
   private final Properties properties;
   private final Boolean readOnly;
   private final Boolean disableLogDirsCollection;

--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/model/KafkaCluster.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/model/KafkaCluster.java
@@ -34,7 +34,7 @@ public class KafkaCluster {
   private final Throwable lastKafkaException;
   private final Throwable lastZookeeperException;
   private final Path protobufFile;
-  private final Map<String,String> protobufMessageName;
+  private final Map<String, String> protobufMessageName;
   private final Properties properties;
   private final Boolean readOnly;
   private final Boolean disableLogDirsCollection;

--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/serde/DeserializationService.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/serde/DeserializationService.java
@@ -35,7 +35,8 @@ public class DeserializationService {
       if (cluster.getProtobufFile() != null) {
         log.info("Using ProtobufFileRecordSerDe for cluster '{}'", cluster.getName());
         return new ProtobufFileRecordSerDe(cluster.getProtobufFile(),
-            cluster.getProtobufMessageName(), objectMapper);
+            cluster.getProtobufMessageNameByTopic(), cluster.getProtobufMessageName(),
+            objectMapper);
       } else {
         log.info("Using SchemaRegistryAwareRecordSerDe for cluster '{}'", cluster.getName());
         return new SchemaRegistryAwareRecordSerDe(cluster);

--- a/kafka-ui-api/src/main/resources/application-local.yml
+++ b/kafka-ui-api/src/main/resources/application-local.yml
@@ -23,8 +23,8 @@ kafka:
   #      name: localUsingProtobufFile
   #      bootstrapServers: localhost:9092
   #      protobufFile: messages.proto
-  #      protobufMessageName:
-  #        _default: GenericMessage
+  #      protobufMessageName: GenericMessage
+  #      protobufMessageNameByTopic:
   #        input-topic: InputMessage
   #        output-topic: OutputMessage
   admin-client-timeout: 5000

--- a/kafka-ui-api/src/main/resources/application-local.yml
+++ b/kafka-ui-api/src/main/resources/application-local.yml
@@ -19,6 +19,14 @@ kafka:
   #          address: http://localhost:8083
   #      jmxPort: 9998
   #      read-only: true
+  #    -
+  #      name: localUsingProtobufFile
+  #      bootstrapServers: localhost:9092
+  #      protobufFile: messages.proto
+  #      protobufMessageName:
+  #        _default: GenericMessage
+  #        input-topic: InputMessage
+  #        output-topic: OutputMessage
   admin-client-timeout: 5000
 zookeeper:
   connection-timeout: 1000

--- a/kafka-ui-api/src/test/java/com/provectus/kafka/ui/serde/ProtobufFileRecordSerDeTest.java
+++ b/kafka-ui-api/src/test/java/com/provectus/kafka/ui/serde/ProtobufFileRecordSerDeTest.java
@@ -1,73 +1,81 @@
 package com.provectus.kafka.ui.serde;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.provectus.kafka.ui.serde.schemaregistry.MessageFormat;
-import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.common.utils.Bytes;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Base64;
 import java.util.Collections;
-import java.util.HashMap;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.Map;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.utils.Bytes;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 class ProtobufFileRecordSerDeTest {
 
-    // Two sample messages used here are generated using `address-book.proto` and contain a person with following email address
-    public static final String TEST_USER_EMAIL = "user@example.com";
-    // Sample message of type `test.Person`
-    private final byte[] personMessage = Base64.getDecoder().decode("CgRVc2VyEGUaEHVzZXJAZXhhbXBsZS5jb20iCgoIMTEyMjMzNDQ=");
-    // Sample message of type `test.AddressBook`
-    private final byte[] addressBookMessage = Base64.getDecoder().decode("CAESJgoEVXNlchBlGhB1c2VyQGV4YW1wbGUuY29tIgoKCDExMjIzMzQ0");
-    private static Path protobufSchema;
+  // Two sample messages used here are generated using `address-book.proto` and contain a person
+  // with following email address
+  public static final String TEST_USER_EMAIL = "user@example.com";
+  // Sample message of type `test.Person`
+  private final byte[] personMessage = Base64.getDecoder()
+      .decode("CgRVc2VyEGUaEHVzZXJAZXhhbXBsZS5jb20iCgoIMTEyMjMzNDQ=");
+  // Sample message of type `test.AddressBook`
+  private final byte[] addressBookMessage = Base64.getDecoder()
+      .decode("CAESJgoEVXNlchBlGhB1c2VyQGV4YW1wbGUuY29tIgoKCDExMjIzMzQ0");
+  private static Path protobufSchema;
 
-    @BeforeAll
-    static void setUp() throws URISyntaxException {
-        protobufSchema = Paths.get(ProtobufFileRecordSerDeTest.class.getClassLoader().getResource("address-book.proto").toURI());
-    }
+  @BeforeAll
+  static void setUp() throws URISyntaxException {
+    protobufSchema = Paths.get(ProtobufFileRecordSerDeTest.class.getClassLoader()
+        .getResource("address-book.proto").toURI());
+  }
 
-    @Test
-    void testDeserialize() throws IOException {
-        var messageNameMap = new HashMap<String, String>() {{
-            put("topic1", "test.Person");
-            put("topic2", "test.AddressBook");
-        }};
-        var deserializer = new ProtobufFileRecordSerDe(protobufSchema, messageNameMap, new ObjectMapper());
-        var msg1 = deserializer.deserialize(new ConsumerRecord<>("topic1", 1, 0, Bytes.wrap("key".getBytes()),
-                Bytes.wrap(personMessage)));
-        assertEquals(MessageFormat.PROTOBUF, msg1.getValueFormat());
-        assertTrue(msg1.getValue().contains(TEST_USER_EMAIL));
+  @Test
+  void testDeserialize() throws IOException {
+    var messageNameMap = Map.of(
+        "topic1", "test.Person",
+        "topic2", "test.AddressBook");
+    var deserializer =
+        new ProtobufFileRecordSerDe(protobufSchema, messageNameMap, new ObjectMapper());
+    var msg1 = deserializer
+        .deserialize(new ConsumerRecord<>("topic1", 1, 0, Bytes.wrap("key".getBytes()),
+            Bytes.wrap(personMessage)));
+    assertEquals(MessageFormat.PROTOBUF, msg1.getValueFormat());
+    assertTrue(msg1.getValue().contains(TEST_USER_EMAIL));
 
-        var msg2 = deserializer.deserialize(new ConsumerRecord<>("topic2", 1, 1, Bytes.wrap("key".getBytes()),
-                Bytes.wrap(addressBookMessage)));
-        assertTrue(msg2.getValue().contains(TEST_USER_EMAIL));
-    }
+    var msg2 = deserializer
+        .deserialize(new ConsumerRecord<>("topic2", 1, 1, Bytes.wrap("key".getBytes()),
+            Bytes.wrap(addressBookMessage)));
+    assertTrue(msg2.getValue().contains(TEST_USER_EMAIL));
+  }
 
-    @Test
-    void testNoDefaultMessageName() throws IOException {
-        // by default the first message type defined in proto definition is used
-        var deserializer = new ProtobufFileRecordSerDe(protobufSchema, Collections.emptyMap(), new ObjectMapper());
-        var msg = deserializer.deserialize(new ConsumerRecord<>("topic", 1, 0, Bytes.wrap("key".getBytes()),
-                Bytes.wrap(personMessage)));
-        assertTrue(msg.getValue().contains(TEST_USER_EMAIL));
-    }
+  @Test
+  void testNoDefaultMessageName() throws IOException {
+    // by default the first message type defined in proto definition is used
+    var deserializer =
+        new ProtobufFileRecordSerDe(protobufSchema, Collections.emptyMap(), new ObjectMapper());
+    var msg = deserializer
+        .deserialize(new ConsumerRecord<>("topic", 1, 0, Bytes.wrap("key".getBytes()),
+            Bytes.wrap(personMessage)));
+    assertTrue(msg.getValue().contains(TEST_USER_EMAIL));
+  }
 
-    @Test
-    void testDefaultMessageName() throws IOException {
-        var messageNameMap = new HashMap<String, String>() {{
-            put("topic1", "test.Person");
-            put("_default", "test.AddressBook");
-        }};
-        var deserializer = new ProtobufFileRecordSerDe(protobufSchema, messageNameMap, new ObjectMapper());
-        var msg = deserializer.deserialize(new ConsumerRecord<>("a_random_topic", 1, 0, Bytes.wrap("key".getBytes()),
-                Bytes.wrap(addressBookMessage)));
-        assertTrue(msg.getValue().contains(TEST_USER_EMAIL));
-    }
+  @Test
+  void testDefaultMessageName() throws IOException {
+    var messageNameMap = Map.of(
+        "topic1", "test.Person",
+        "_default", "test.AddressBook");
+    var deserializer =
+        new ProtobufFileRecordSerDe(protobufSchema, messageNameMap, new ObjectMapper());
+    var msg = deserializer
+        .deserialize(new ConsumerRecord<>("a_random_topic", 1, 0, Bytes.wrap("key".getBytes()),
+            Bytes.wrap(addressBookMessage)));
+    assertTrue(msg.getValue().contains(TEST_USER_EMAIL));
+  }
 }

--- a/kafka-ui-api/src/test/java/com/provectus/kafka/ui/serde/ProtobufFileRecordSerDeTest.java
+++ b/kafka-ui-api/src/test/java/com/provectus/kafka/ui/serde/ProtobufFileRecordSerDeTest.java
@@ -1,6 +1,7 @@
 package com.provectus.kafka.ui.serde;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -87,5 +88,15 @@ class ProtobufFileRecordSerDeTest {
         .deserialize(new ConsumerRecord<>("a_random_topic", 1, 0, Bytes.wrap("key".getBytes()),
             Bytes.wrap(addressBookMessage)));
     assertTrue(msg.getValue().contains("user2@example.com"));
+  }
+
+  @Test
+  void testSerialize() throws IOException {
+    var messageNameMap = Map.of("topic1", "test.Person");
+    var serializer =
+        new ProtobufFileRecordSerDe(protobufSchemaPath, messageNameMap, "test.AddressBook",
+            new ObjectMapper());
+    var serialized = serializer.serialize("topic1", "key1", "{\"name\":\"MyName\"}", 0);
+    assertNotNull(serialized.value());
   }
 }

--- a/kafka-ui-api/src/test/java/com/provectus/kafka/ui/serde/ProtobufFileRecordSerDeTest.java
+++ b/kafka-ui-api/src/test/java/com/provectus/kafka/ui/serde/ProtobufFileRecordSerDeTest.java
@@ -1,0 +1,73 @@
+package com.provectus.kafka.ui.serde;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.provectus.kafka.ui.serde.schemaregistry.MessageFormat;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.utils.Bytes;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ProtobufFileRecordSerDeTest {
+
+    // Two sample messages used here are generated using `address-book.proto` and contain a person with following email address
+    public static final String TEST_USER_EMAIL = "user@example.com";
+    // Sample message of type `test.Person`
+    private final byte[] personMessage = Base64.getDecoder().decode("CgRVc2VyEGUaEHVzZXJAZXhhbXBsZS5jb20iCgoIMTEyMjMzNDQ=");
+    // Sample message of type `test.AddressBook`
+    private final byte[] addressBookMessage = Base64.getDecoder().decode("CAESJgoEVXNlchBlGhB1c2VyQGV4YW1wbGUuY29tIgoKCDExMjIzMzQ0");
+    private static Path protobufSchema;
+
+    @BeforeAll
+    static void setUp() throws URISyntaxException {
+        protobufSchema = Paths.get(ProtobufFileRecordSerDeTest.class.getClassLoader().getResource("address-book.proto").toURI());
+    }
+
+    @Test
+    void testDeserialize() throws IOException {
+        var messageNameMap = new HashMap<String, String>() {{
+            put("topic1", "test.Person");
+            put("topic2", "test.AddressBook");
+        }};
+        var deserializer = new ProtobufFileRecordSerDe(protobufSchema, messageNameMap, new ObjectMapper());
+        var msg1 = deserializer.deserialize(new ConsumerRecord<>("topic1", 1, 0, Bytes.wrap("key".getBytes()),
+                Bytes.wrap(personMessage)));
+        assertEquals(MessageFormat.PROTOBUF, msg1.getValueFormat());
+        assertTrue(msg1.getValue().contains(TEST_USER_EMAIL));
+
+        var msg2 = deserializer.deserialize(new ConsumerRecord<>("topic2", 1, 1, Bytes.wrap("key".getBytes()),
+                Bytes.wrap(addressBookMessage)));
+        assertTrue(msg2.getValue().contains(TEST_USER_EMAIL));
+    }
+
+    @Test
+    void testNoDefaultMessageName() throws IOException {
+        // by default the first message type defined in proto definition is used
+        var deserializer = new ProtobufFileRecordSerDe(protobufSchema, Collections.emptyMap(), new ObjectMapper());
+        var msg = deserializer.deserialize(new ConsumerRecord<>("topic", 1, 0, Bytes.wrap("key".getBytes()),
+                Bytes.wrap(personMessage)));
+        assertTrue(msg.getValue().contains(TEST_USER_EMAIL));
+    }
+
+    @Test
+    void testDefaultMessageName() throws IOException {
+        var messageNameMap = new HashMap<String, String>() {{
+            put("topic1", "test.Person");
+            put("_default", "test.AddressBook");
+        }};
+        var deserializer = new ProtobufFileRecordSerDe(protobufSchema, messageNameMap, new ObjectMapper());
+        var msg = deserializer.deserialize(new ConsumerRecord<>("a_random_topic", 1, 0, Bytes.wrap("key".getBytes()),
+                Bytes.wrap(addressBookMessage)));
+        assertTrue(msg.getValue().contains(TEST_USER_EMAIL));
+    }
+}

--- a/kafka-ui-api/src/test/resources/address-book.proto
+++ b/kafka-ui-api/src/test/resources/address-book.proto
@@ -1,0 +1,39 @@
+// [START declaration]
+syntax = "proto3";
+package test;
+
+// [END declaration]
+
+// [START java_declaration]
+option java_multiple_files = true;
+option java_package = "com.example.tutorial.protos";
+option java_outer_classname = "AddressBookProtos";
+// [END java_declaration]
+
+// [START messages]
+message Person {
+  string name = 1;
+  int32 id = 2;  // Unique ID number for this person.
+  string email = 3;
+
+  enum PhoneType {
+    MOBILE = 0;
+    HOME = 1;
+    WORK = 2;
+  }
+
+  message PhoneNumber {
+    string number = 1;
+    PhoneType type = 2;
+  }
+
+  repeated PhoneNumber phones = 4;
+
+}
+
+// Our address book file is just one of these.
+message AddressBook {
+  int32 version = 1;
+  repeated Person people = 2;
+}
+// [END messages]


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** 
<!-- ignore-task-list-end -->
**What changes did you make?** Added the ability to specify separate message types for each topic when using ProtobufFile for deserialization. The configuration `protobufMessageName` is now a map between the topic name and the message name. The key `_default` is used for specifying the message name for all other topics not defined explicitly.

**Is there anything you'd like reviewers to focus on?**


**How Has This Been Tested?** (put an "X" next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually(please, describe, when necessary)
- [x] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "X" next to an item, otherwise PR will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings(e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/provectus/kafka-ui/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/provectus/kafka-ui/blob/master/CODE-OF-CONDUCT.md)