### PR TITLE
Fix redirect after resetting consumer group offsets

### DIFF
--- a/kafka-ui-react-app/src/redux/reducers/consumerGroups/selectors.ts
+++ b/kafka-ui-react-app/src/redux/reducers/consumerGroups/selectors.ts
@@ -25,7 +25,7 @@ const getConsumerGroupDeletingStatus = createFetchingSelector(
   'DELETE_CONSUMER_GROUP'
 );
 
-const getOffsetResettingStatus = createFetchingSelector('RESET_OFFSET_GROUP');
+const getOffsetResettingStatus = createFetchingSelector('RESET_OFFSETS');
 
 export const getIsConsumerGroupsListFetched = createSelector(
   getConsumerGroupsListFetchingStatus,


### PR DESCRIPTION
For some reason, there was a wrong action name in the fetching selector.