### PR TITLE
Custom Inputs 

### DIFF
--- a/kafka-ui-react-app/src/components/Topics/List/__tests__/__snapshots__/List.spec.tsx.snap
+++ b/kafka-ui-react-app/src/components/Topics/List/__tests__/__snapshots__/List.spec.tsx.snap
@@ -97,47 +97,53 @@ exports[`List when it does not have readonly flag matches the snapshot 1`] = `
                 placeholder="Search by Topic Name"
                 value=""
               >
-                <Input
+                <Styled(Input)
                   defaultValue=""
                   leftIcon="fas fa-search"
                   onChange={[Function]}
                   placeholder="Search by Topic Name"
                   type="text"
                 >
-                  <div
-                    style={
-                      Object {
-                        "position": "relative",
-                      }
-                    }
+                  <Input
+                    className="sc-dlfnuX gxtwfA"
+                    defaultValue=""
+                    leftIcon="fas fa-search"
+                    onChange={[Function]}
+                    placeholder="Search by Topic Name"
+                    type="text"
                   >
-                    <styled.i
-                      className="fas fa-search"
-                      inputSize="L"
-                      position="left"
+                    <div
+                      className="sc-dlfnuX gxtwfA"
                     >
-                      <i
-                        className="sc-bdfBQB eVEGAa fas fa-search"
-                      />
-                    </styled.i>
-                    <styled.input
-                      defaultValue=""
-                      hasLeftIcon={true}
-                      inputSize="L"
-                      onChange={[Function]}
-                      placeholder="Search by Topic Name"
-                      type="text"
-                    >
-                      <input
-                        className="sc-gsTEea eQzZSW"
+                      <styled.i
+                        className="fas fa-search"
+                        inputSize="L"
+                        position="left"
+                      >
+                        <i
+                          className="sc-bdfBQB eaUARU fas fa-search"
+                        />
+                      </styled.i>
+                      <styled.input
+                        className="sc-dlfnuX gxtwfA"
                         defaultValue=""
+                        hasLeftIcon={true}
+                        inputSize="L"
                         onChange={[Function]}
                         placeholder="Search by Topic Name"
                         type="text"
-                      />
-                    </styled.input>
-                  </div>
-                </Input>
+                      >
+                        <input
+                          className="sc-gsTEea eQzZSW sc-dlfnuX gxtwfA"
+                          defaultValue=""
+                          onChange={[Function]}
+                          placeholder="Search by Topic Name"
+                          type="text"
+                        />
+                      </styled.input>
+                    </div>
+                  </Input>
+                </Styled(Input)>
               </Search>
             </div>
             <div

--- a/kafka-ui-react-app/src/components/Topics/List/__tests__/__snapshots__/List.spec.tsx.snap
+++ b/kafka-ui-react-app/src/components/Topics/List/__tests__/__snapshots__/List.spec.tsx.snap
@@ -97,24 +97,47 @@ exports[`List when it does not have readonly flag matches the snapshot 1`] = `
                 placeholder="Search by Topic Name"
                 value=""
               >
-                <p
-                  className="control has-icons-left"
+                <Input
+                  defaultValue=""
+                  leftIcon="fas fa-search"
+                  onChange={[Function]}
+                  placeholder="Search by Topic Name"
+                  type="text"
                 >
-                  <input
-                    className="input"
-                    defaultValue=""
-                    onChange={[Function]}
-                    placeholder="Search by Topic Name"
-                    type="text"
-                  />
-                  <span
-                    className="icon is-small is-left"
+                  <div
+                    style={
+                      Object {
+                        "position": "relative",
+                      }
+                    }
                   >
-                    <i
+                    <styled.i
                       className="fas fa-search"
-                    />
-                  </span>
-                </p>
+                      inputSize="L"
+                      position="left"
+                    >
+                      <i
+                        className="sc-bdfBQB eVEGAa fas fa-search"
+                      />
+                    </styled.i>
+                    <styled.input
+                      defaultValue=""
+                      hasLeftIcon={true}
+                      inputSize="L"
+                      onChange={[Function]}
+                      placeholder="Search by Topic Name"
+                      type="text"
+                    >
+                      <input
+                        className="sc-gsTEea eQzZSW"
+                        defaultValue=""
+                        onChange={[Function]}
+                        placeholder="Search by Topic Name"
+                        type="text"
+                      />
+                    </styled.input>
+                  </div>
+                </Input>
               </Search>
             </div>
             <div

--- a/kafka-ui-react-app/src/components/Topics/List/__tests__/__snapshots__/List.spec.tsx.snap
+++ b/kafka-ui-react-app/src/components/Topics/List/__tests__/__snapshots__/List.spec.tsx.snap
@@ -121,7 +121,7 @@ exports[`List when it does not have readonly flag matches the snapshot 1`] = `
                         position="left"
                       >
                         <i
-                          className="sc-bdfBQB eaUARU fas fa-search"
+                          className="sc-bdfBQB gNwdVP fas fa-search"
                         />
                       </styled.i>
                       <styled.input

--- a/kafka-ui-react-app/src/components/Topics/New/New.tsx
+++ b/kafka-ui-react-app/src/components/Topics/New/New.tsx
@@ -12,38 +12,15 @@ import { useDispatch } from 'react-redux';
 import { getResponse } from 'lib/errorHandling';
 import { useHistory, useParams } from 'react-router';
 import { yupResolver } from '@hookform/resolvers/yup';
-import yup from 'lib/yupExtended';
-import { TOPIC_NAME_VALIDATION_PATTERN } from 'lib/constants';
+import { topicFormValidationSchema } from 'lib/yupExtended';
 
 interface RouterParams {
   clusterName: ClusterName;
 }
-const validationSchema = yup.object().shape({
-  name: yup
-    .string()
-    .required()
-    .matches(
-      TOPIC_NAME_VALIDATION_PATTERN,
-      'Only alphanumeric, _, -, and . allowed'
-    ),
-  partitions: yup.number().required(),
-  replicationFactor: yup.number().required(),
-  minInSyncReplicas: yup.number().required(),
-  cleanupPolicy: yup.string().required(),
-  retentionMs: yup.number().min(-1, 'Must be greater than or equal to -1'),
-  retentionBytes: yup.number(),
-  maxMessageBytes: yup.number().required(),
-  customParams: yup.array().of(
-    yup.object().shape({
-      name: yup.string().required(),
-      value: yup.string().required(),
-    })
-  ),
-});
 
 const New: React.FC = () => {
   const methods = useForm<TopicFormData>({
-    resolver: yupResolver(validationSchema),
+    resolver: yupResolver(topicFormValidationSchema),
   });
   const { clusterName } = useParams<RouterParams>();
   const history = useHistory();

--- a/kafka-ui-react-app/src/components/Topics/New/New.tsx
+++ b/kafka-ui-react-app/src/components/Topics/New/New.tsx
@@ -11,13 +11,40 @@ import {
 import { useDispatch } from 'react-redux';
 import { getResponse } from 'lib/errorHandling';
 import { useHistory, useParams } from 'react-router';
+import { yupResolver } from '@hookform/resolvers/yup';
+import yup from 'lib/yupExtended';
+import { TOPIC_NAME_VALIDATION_PATTERN } from 'lib/constants';
 
 interface RouterParams {
   clusterName: ClusterName;
 }
+const validationSchema = yup.object().shape({
+  name: yup
+    .string()
+    .required()
+    .matches(
+      TOPIC_NAME_VALIDATION_PATTERN,
+      'Only alphanumeric, _, -, and . allowed'
+    ),
+  partitions: yup.number().required(),
+  replicationFactor: yup.number().required(),
+  minInSyncReplicas: yup.number().required(),
+  cleanupPolicy: yup.string().required(),
+  retentionMs: yup.number().min(-1, 'Must be greater than or equal to -1'),
+  retentionBytes: yup.number(),
+  maxMessageBytes: yup.number().required(),
+  customParams: yup.array().of(
+    yup.object().shape({
+      name: yup.string().required(),
+      value: yup.string().required(),
+    })
+  ),
+});
 
 const New: React.FC = () => {
-  const methods = useForm<TopicFormData>();
+  const methods = useForm<TopicFormData>({
+    resolver: yupResolver(validationSchema),
+  });
   const { clusterName } = useParams<RouterParams>();
   const history = useHistory();
   const dispatch = useDispatch();

--- a/kafka-ui-react-app/src/components/Topics/New/__tests__/New.spec.tsx
+++ b/kafka-ui-react-app/src/components/Topics/New/__tests__/New.spec.tsx
@@ -8,6 +8,8 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 import fetchMock from 'fetch-mock-jest';
 import { clusterTopicNewPath, clusterTopicPath } from 'lib/paths';
+import { ThemeProvider } from 'styled-components';
+import theme from 'theme/theme';
 
 const mockStore = configureStore();
 
@@ -26,7 +28,9 @@ describe('New', () => {
   const setupComponent = (history = historyMock, store = storeMock) => (
     <Router history={history}>
       <Provider store={store}>
-        <New />
+        <ThemeProvider theme={theme}>
+          <New />
+        </ThemeProvider>
       </Provider>
     </Router>
   );

--- a/kafka-ui-react-app/src/components/Topics/New/__tests__/New.spec.tsx
+++ b/kafka-ui-react-app/src/components/Topics/New/__tests__/New.spec.tsx
@@ -43,7 +43,7 @@ describe('New', () => {
 
     await waitFor(async () => {
       fireEvent.click(await screen.findByText('Send'));
-      const errorText = await screen.findByText('Topic Name is required.');
+      const errorText = await screen.findByText('name is a required field');
       expect(mockedHistory.push).toBeCalledTimes(0);
       expect(errorText).toBeTruthy();
     });

--- a/kafka-ui-react-app/src/components/Topics/Topic/Edit/Edit.tsx
+++ b/kafka-ui-react-app/src/components/Topics/Topic/Edit/Edit.tsx
@@ -14,8 +14,7 @@ import TopicForm from 'components/Topics/shared/Form/TopicForm';
 import { clusterTopicPath } from 'lib/paths';
 import { useHistory } from 'react-router';
 import { yupResolver } from '@hookform/resolvers/yup';
-import yup from 'lib/yupExtended';
-import { TOPIC_NAME_VALIDATION_PATTERN } from 'lib/constants';
+import { topicFormValidationSchema } from 'lib/yupExtended';
 
 import DangerZoneContainer from './DangerZoneContainer';
 
@@ -46,29 +45,6 @@ const DEFAULTS = {
   retentionBytes: -1,
   maxMessageBytes: 1000012,
 };
-
-const validationSchema = yup.object().shape({
-  name: yup
-    .string()
-    .required()
-    .matches(
-      TOPIC_NAME_VALIDATION_PATTERN,
-      'Only alphanumeric, _, -, and . allowed'
-    ),
-  partitions: yup.number().required(),
-  replicationFactor: yup.number().required(),
-  minInSyncReplicas: yup.number().required(),
-  cleanupPolicy: yup.string().required(),
-  retentionMs: yup.number().min(-1, 'Must be greater than or equal to -1'),
-  retentionBytes: yup.number(),
-  maxMessageBytes: yup.number().required(),
-  customParams: yup.array().of(
-    yup.object().shape({
-      name: yup.string().required(),
-      value: yup.string().required(),
-    })
-  ),
-});
 
 const topicParams = (topic: TopicWithDetailedInfo | undefined) => {
   if (!topic) {
@@ -112,7 +88,7 @@ const Edit: React.FC<Props> = ({
 
   const methods = useForm<TopicFormData>({
     defaultValues,
-    resolver: yupResolver(validationSchema),
+    resolver: yupResolver(topicFormValidationSchema),
   });
 
   const [isSubmitting, setIsSubmitting] = React.useState<boolean>(false);

--- a/kafka-ui-react-app/src/components/Topics/shared/Form/TopicForm.tsx
+++ b/kafka-ui-react-app/src/components/Topics/shared/Form/TopicForm.tsx
@@ -3,6 +3,8 @@ import { useFormContext } from 'react-hook-form';
 import { TOPIC_NAME_VALIDATION_PATTERN, BYTES_IN_GB } from 'lib/constants';
 import { TopicName, TopicConfigByName } from 'redux/interfaces';
 import { ErrorMessage } from '@hookform/error-message';
+import Input from 'components/common/Input/Input';
+import { Button } from 'components/common/Button/Button';
 
 import CustomParamsContainer from './CustomParams/CustomParamsContainer';
 import TimeToRetain from './TimeToRetain';
@@ -34,18 +36,17 @@ const TopicForm: React.FC<Props> = ({
           <div className="columns">
             <div className={`column ${isEditing ? '' : 'is-three-quarters'}`}>
               <label className="label">Topic Name *</label>
-              <input
-                className="input"
+              <Input
+                name="name"
                 placeholder="Topic Name"
                 defaultValue={topicName}
-                {...register('name', {
+                hookFormOptions={{
                   required: 'Topic Name is required.',
                   pattern: {
                     value: TOPIC_NAME_VALIDATION_PATTERN,
                     message: 'Only alphanumeric, _, -, and . allowed',
                   },
-                })}
-                autoComplete="off"
+                }}
               />
               <p className="help is-danger">
                 <ErrorMessage errors={errors} name="name" />
@@ -55,14 +56,15 @@ const TopicForm: React.FC<Props> = ({
             {!isEditing && (
               <div className="column">
                 <label className="label">Number of partitions *</label>
-                <input
+                <Input
                   className="input"
                   type="number"
                   placeholder="Number of partitions"
                   defaultValue="1"
-                  {...register('partitions', {
+                  name="partitions"
+                  hookFormOptions={{
                     required: 'Number of partitions is required.',
-                  })}
+                  }}
                 />
                 <p className="help is-danger">
                   <ErrorMessage errors={errors} name="partitions" />
@@ -76,14 +78,15 @@ const TopicForm: React.FC<Props> = ({
           {!isEditing && (
             <div className="column">
               <label className="label">Replication Factor *</label>
-              <input
+              <Input
                 className="input"
                 type="number"
                 placeholder="Replication Factor"
                 defaultValue="1"
-                {...register('replicationFactor', {
+                name="replicationFactor"
+                hookFormOptions={{
                   required: 'Replication Factor is required.',
-                })}
+                }}
               />
               <p className="help is-danger">
                 <ErrorMessage errors={errors} name="replicationFactor" />
@@ -93,14 +96,15 @@ const TopicForm: React.FC<Props> = ({
 
           <div className="column">
             <label className="label">Min In Sync Replicas *</label>
-            <input
+            <Input
               className="input"
               type="number"
               placeholder="Min In Sync Replicas"
               defaultValue="1"
-              {...register('minInSyncReplicas', {
+              name="minInSyncReplicas"
+              hookFormOptions={{
                 required: 'Min In Sync Replicas is required.',
-              })}
+              }}
             />
             <p className="help is-danger">
               <ErrorMessage errors={errors} name="minInSyncReplicas" />
@@ -140,13 +144,14 @@ const TopicForm: React.FC<Props> = ({
         <div className="columns">
           <div className="column">
             <label className="label">Maximum message size in bytes *</label>
-            <input
+            <Input
               className="input"
               type="number"
               defaultValue="1000012"
-              {...register('maxMessageBytes', {
+              name="maxMessageBytes"
+              hookFormOptions={{
                 required: 'Maximum message size in bytes is required',
-              })}
+              }}
             />
             <p className="help is-danger">
               <ErrorMessage errors={errors} name="maxMessageBytes" />
@@ -156,7 +161,10 @@ const TopicForm: React.FC<Props> = ({
 
         <CustomParamsContainer isSubmitting={isSubmitting} config={config} />
 
-        <input type="submit" className="button is-primary" value="Send" />
+        <Button type="submit" buttonType="primary" buttonSize="L">
+          {' '}
+          Send{' '}
+        </Button>
       </fieldset>
     </form>
   );

--- a/kafka-ui-react-app/src/components/Topics/shared/Form/TopicForm.tsx
+++ b/kafka-ui-react-app/src/components/Topics/shared/Form/TopicForm.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useFormContext } from 'react-hook-form';
-import { TOPIC_NAME_VALIDATION_PATTERN, BYTES_IN_GB } from 'lib/constants';
+import { BYTES_IN_GB } from 'lib/constants';
 import { TopicName, TopicConfigByName } from 'redux/interfaces';
 import { ErrorMessage } from '@hookform/error-message';
 import Input from 'components/common/Input/Input';
@@ -40,13 +40,6 @@ const TopicForm: React.FC<Props> = ({
                 name="name"
                 placeholder="Topic Name"
                 defaultValue={topicName}
-                hookFormOptions={{
-                  required: 'Topic Name is required.',
-                  pattern: {
-                    value: TOPIC_NAME_VALIDATION_PATTERN,
-                    message: 'Only alphanumeric, _, -, and . allowed',
-                  },
-                }}
               />
               <p className="help is-danger">
                 <ErrorMessage errors={errors} name="name" />
@@ -57,14 +50,10 @@ const TopicForm: React.FC<Props> = ({
               <div className="column">
                 <label className="label">Number of partitions *</label>
                 <Input
-                  className="input"
                   type="number"
                   placeholder="Number of partitions"
                   defaultValue="1"
                   name="partitions"
-                  hookFormOptions={{
-                    required: 'Number of partitions is required.',
-                  }}
                 />
                 <p className="help is-danger">
                   <ErrorMessage errors={errors} name="partitions" />
@@ -79,14 +68,10 @@ const TopicForm: React.FC<Props> = ({
             <div className="column">
               <label className="label">Replication Factor *</label>
               <Input
-                className="input"
                 type="number"
                 placeholder="Replication Factor"
                 defaultValue="1"
                 name="replicationFactor"
-                hookFormOptions={{
-                  required: 'Replication Factor is required.',
-                }}
               />
               <p className="help is-danger">
                 <ErrorMessage errors={errors} name="replicationFactor" />
@@ -97,14 +82,10 @@ const TopicForm: React.FC<Props> = ({
           <div className="column">
             <label className="label">Min In Sync Replicas *</label>
             <Input
-              className="input"
               type="number"
               placeholder="Min In Sync Replicas"
               defaultValue="1"
               name="minInSyncReplicas"
-              hookFormOptions={{
-                required: 'Min In Sync Replicas is required.',
-              }}
             />
             <p className="help is-danger">
               <ErrorMessage errors={errors} name="minInSyncReplicas" />
@@ -145,13 +126,9 @@ const TopicForm: React.FC<Props> = ({
           <div className="column">
             <label className="label">Maximum message size in bytes *</label>
             <Input
-              className="input"
               type="number"
               defaultValue="1000012"
               name="maxMessageBytes"
-              hookFormOptions={{
-                required: 'Maximum message size in bytes is required',
-              }}
             />
             <p className="help is-danger">
               <ErrorMessage errors={errors} name="maxMessageBytes" />
@@ -162,8 +139,7 @@ const TopicForm: React.FC<Props> = ({
         <CustomParamsContainer isSubmitting={isSubmitting} config={config} />
 
         <Button type="submit" buttonType="primary" buttonSize="L">
-          {' '}
-          Send{' '}
+          Send
         </Button>
       </fieldset>
     </form>

--- a/kafka-ui-react-app/src/components/common/Button/Button.styled.ts
+++ b/kafka-ui-react-app/src/components/common/Button/Button.styled.ts
@@ -6,7 +6,7 @@ export interface ButtonProps {
   isInverted?: boolean;
 }
 
-const StyledButton = styled('button')<ButtonProps>`
+const StyledButton = styled.button<ButtonProps>`
   display: flex;
   flex-direction: row;
   align-items: center;

--- a/kafka-ui-react-app/src/components/common/Button/Button.tsx
+++ b/kafka-ui-react-app/src/components/common/Button/Button.tsx
@@ -3,7 +3,9 @@ import StyledButton, {
 } from 'components/common/Button/Button.styled';
 import React from 'react';
 
-type Props = ButtonProps;
+interface Props
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    ButtonProps {}
 
 export const Button: React.FC<Props> = (props) => {
   return <StyledButton {...props} />;

--- a/kafka-ui-react-app/src/components/common/Input/Input.styled.ts
+++ b/kafka-ui-react-app/src/components/common/Input/Input.styled.ts
@@ -1,12 +1,12 @@
 import styled from 'styled-components';
 import { Colors } from 'theme/theme';
 
-interface Props {
-  inputSize: 'M' | 'L';
+export interface StyledInputProps {
+  inputSize?: 'M' | 'L';
   hasLeftIcon: boolean;
 }
 
-const StyledInput = styled.input<Props>`
+const StyledInput = styled.input<StyledInputProps>`
   border: 1px ${Colors.neutral[30]} solid;
   border-radius: 4px;
   height: ${(props) => (props.inputSize === 'M' ? '32px' : '40px')};

--- a/kafka-ui-react-app/src/components/common/Input/Input.styled.ts
+++ b/kafka-ui-react-app/src/components/common/Input/Input.styled.ts
@@ -1,0 +1,49 @@
+import styled from 'styled-components';
+import { Colors } from 'theme/theme';
+
+interface Props {
+  inputSize: 'M' | 'L';
+  hasLeftIcon: boolean;
+}
+
+const StyledInput = styled.input<Props>`
+  border: 1px ${Colors.neutral[30]} solid;
+  border-radius: 4px;
+  height: ${(props) => (props.inputSize === 'M' ? '32px' : '40px')};
+  width: 100%;
+  padding-left: ${(props) => (props.hasLeftIcon ? '36px' : '12px')};
+  font-size: 14px;
+
+  &::placeholder {
+    color: ${Colors.neutral[30]};
+    font-size: 14px;
+  }
+  &:hover {
+    border-color: ${Colors.neutral[50]};
+  }
+  &:focus {
+    outline: none;
+    border-color: ${Colors.neutral[70]};
+    &::placeholder {
+      color: transparent;
+    }
+  }
+  &:disabled {
+    color: ${Colors.neutral[30]};
+    border-color: ${Colors.neutral[10]};
+    cursor: not-allowed;
+  }
+  &:read-only {
+    color: ${Colors.neutral[90]};
+    border: none;
+    background-color: ${Colors.neutral[5]};
+    &:focus {
+      &::placeholder {
+        color: ${Colors.neutral[30]};
+      }
+    }
+    cursor: not-allowed;
+  }
+`;
+
+export default StyledInput;

--- a/kafka-ui-react-app/src/components/common/Input/Input.tsx
+++ b/kafka-ui-react-app/src/components/common/Input/Input.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
-import { useFormContext, RegisterOptions } from 'react-hook-form';
+import { useFormContext } from 'react-hook-form';
+import { styled } from 'lib/themedStyles';
 
 import StyledIcon from './InputIcon.styled';
 import StyledInput from './Input.styled';
 
 export interface InputProps
   extends React.InputHTMLAttributes<HTMLInputElement> {
+  className?: string;
   name?: string;
-  hookFormOptions?: RegisterOptions;
   inputSize?: 'M' | 'L';
   leftIcon?: string;
   rightIcon?: string;
@@ -16,44 +17,50 @@ export interface InputProps
 const Input: React.FC<InputProps> = ({
   className,
   name,
-  hookFormOptions,
   leftIcon,
   rightIcon,
-  inputSize,
+  inputSize = 'L',
   ...rest
 }) => {
-  const size = inputSize || 'L'; // default size is L
   const methods = useFormContext();
   return (
-    <div
-      style={{
-        position: 'relative',
-      }}
-    >
+    <div className={className}>
       {leftIcon && (
-        <StyledIcon className={leftIcon} position="left" inputSize={size} />
+        <StyledIcon
+          className={leftIcon}
+          position="left"
+          inputSize={inputSize}
+        />
       )}
       {name ? (
         <StyledInput
           className={className}
-          inputSize={size}
-          {...methods.register(name, { ...hookFormOptions })}
+          inputSize={inputSize}
+          {...methods.register(name)}
           hasLeftIcon={!!leftIcon}
           {...rest}
         />
       ) : (
         <StyledInput
           className={className}
-          inputSize={size}
+          inputSize={inputSize}
           hasLeftIcon={!!leftIcon}
           {...rest}
         />
       )}
       {rightIcon && (
-        <StyledIcon className={rightIcon} position="right" inputSize={size} />
+        <StyledIcon
+          className={rightIcon}
+          position="right"
+          inputSize={inputSize}
+        />
       )}
     </div>
   );
 };
 
-export default Input;
+const InputWrapper = styled(Input)`
+  position: relative;
+`;
+
+export default InputWrapper;

--- a/kafka-ui-react-app/src/components/common/Input/Input.tsx
+++ b/kafka-ui-react-app/src/components/common/Input/Input.tsx
@@ -3,13 +3,12 @@ import { useFormContext } from 'react-hook-form';
 import { styled } from 'lib/themedStyles';
 
 import StyledIcon from './InputIcon.styled';
-import StyledInput from './Input.styled';
+import StyledInput, { StyledInputProps } from './Input.styled';
 
 export interface InputProps
-  extends React.InputHTMLAttributes<HTMLInputElement> {
-  className?: string;
+  extends React.InputHTMLAttributes<HTMLInputElement>,
+    Omit<StyledInputProps, 'hasLeftIcon'> {
   name?: string;
-  inputSize?: 'M' | 'L';
   leftIcon?: string;
   rightIcon?: string;
 }

--- a/kafka-ui-react-app/src/components/common/Input/Input.tsx
+++ b/kafka-ui-react-app/src/components/common/Input/Input.tsx
@@ -6,7 +6,7 @@ import StyledInput from './Input.styled';
 
 export interface InputProps
   extends React.InputHTMLAttributes<HTMLInputElement> {
-  name: string;
+  name?: string;
   hookFormOptions?: RegisterOptions;
   inputSize?: 'M' | 'L';
   leftIcon?: string;
@@ -23,7 +23,7 @@ const Input: React.FC<InputProps> = ({
   ...rest
 }) => {
   const size = inputSize || 'L'; // default size is L
-  const { register } = useFormContext();
+  const methods = useFormContext();
   return (
     <div
       style={{
@@ -33,13 +33,22 @@ const Input: React.FC<InputProps> = ({
       {leftIcon && (
         <StyledIcon className={leftIcon} position="left" inputSize={size} />
       )}
-      <StyledInput
-        className={className}
-        inputSize={size}
-        {...register(name, { ...hookFormOptions })}
-        hasLeftIcon={!!leftIcon}
-        {...rest}
-      />
+      {name ? (
+        <StyledInput
+          className={className}
+          inputSize={size}
+          {...methods.register(name, { ...hookFormOptions })}
+          hasLeftIcon={!!leftIcon}
+          {...rest}
+        />
+      ) : (
+        <StyledInput
+          className={className}
+          inputSize={size}
+          hasLeftIcon={!!leftIcon}
+          {...rest}
+        />
+      )}
       {rightIcon && (
         <StyledIcon className={rightIcon} position="right" inputSize={size} />
       )}

--- a/kafka-ui-react-app/src/components/common/Input/Input.tsx
+++ b/kafka-ui-react-app/src/components/common/Input/Input.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { useFormContext, RegisterOptions } from 'react-hook-form';
+
+import StyledIcon from './InputIcon.styled';
+import StyledInput from './Input.styled';
+
+export interface InputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {
+  name: string;
+  hookFormOptions?: RegisterOptions;
+  inputSize?: 'M' | 'L';
+  leftIcon?: string;
+  rightIcon?: string;
+}
+
+const Input: React.FC<InputProps> = ({
+  className,
+  name,
+  hookFormOptions,
+  leftIcon,
+  rightIcon,
+  inputSize,
+  ...rest
+}) => {
+  const size = inputSize || 'L'; // default size is L
+  const { register } = useFormContext();
+  return (
+    <div
+      style={{
+        position: 'relative',
+      }}
+    >
+      {leftIcon && (
+        <StyledIcon className={leftIcon} position="left" inputSize={size} />
+      )}
+      <StyledInput
+        className={className}
+        inputSize={size}
+        {...register(name, { ...hookFormOptions })}
+        hasLeftIcon={!!leftIcon}
+        {...rest}
+      />
+      {rightIcon && (
+        <StyledIcon className={rightIcon} position="right" inputSize={size} />
+      )}
+    </div>
+  );
+};
+
+export default Input;

--- a/kafka-ui-react-app/src/components/common/Input/InputIcon.styled.ts
+++ b/kafka-ui-react-app/src/components/common/Input/InputIcon.styled.ts
@@ -10,9 +10,10 @@ interface Props {
 const StyledIcon = styled.i<Props>`
   position: absolute;
   top: 50%;
-  transform: translate3d(0, -60%, 0);
+  line-height: 0;
   z-index: 1;
-  left: ${(props) => (props.position === 'left' ? '12px' : '97%')};
+  left: ${(props) => (props.position === 'left' ? '12px' : 'unset')};
+  right: ${(props) => (props.position === 'right' ? '15px' : 'unset')};
   height: 11px;
   width: 11px;
   color: ${Colors.neutral[70]};

--- a/kafka-ui-react-app/src/components/common/Input/InputIcon.styled.ts
+++ b/kafka-ui-react-app/src/components/common/Input/InputIcon.styled.ts
@@ -1,0 +1,19 @@
+import styled from 'styled-components';
+import { Colors } from 'theme/theme';
+
+interface Props {
+  className: string;
+  position: 'left' | 'right';
+  inputSize: 'M' | 'L';
+}
+
+const StyledIcon = styled.i<Props>`
+  position: absolute;
+  top: ${(props) => (props.inputSize === 'M' ? '8px' : '12px')};
+  left: ${(props) => (props.position === 'left' ? '12px' : '97%')};
+  height: 11px;
+  width: 11px;
+  color: ${Colors.neutral[70]};
+`;
+
+export default StyledIcon;

--- a/kafka-ui-react-app/src/components/common/Input/InputIcon.styled.ts
+++ b/kafka-ui-react-app/src/components/common/Input/InputIcon.styled.ts
@@ -9,7 +9,9 @@ interface Props {
 
 const StyledIcon = styled.i<Props>`
   position: absolute;
-  top: ${(props) => (props.inputSize === 'M' ? '8px' : '12px')};
+  top: 50%;
+  transform: translate3d(0, -60%, 0);
+  z-index: 1;
   left: ${(props) => (props.position === 'left' ? '12px' : '97%')};
   height: 11px;
   width: 11px;

--- a/kafka-ui-react-app/src/components/common/Input/__tests__/Input.spec.tsx
+++ b/kafka-ui-react-app/src/components/common/Input/__tests__/Input.spec.tsx
@@ -1,0 +1,36 @@
+import Input, { InputProps } from 'components/common/Input/Input';
+import { ThemeProvider } from 'styled-components';
+import theme from 'theme/theme';
+import React from 'react';
+import { render } from '@testing-library/react';
+
+const setupWrapper = (props?: Partial<InputProps>) => (
+  <ThemeProvider theme={theme}>
+    <Input name="test" {...props} />
+  </ThemeProvider>
+);
+jest.mock('react-hook-form', () => ({
+  useFormContext: () => ({
+    register: jest.fn(),
+  }),
+}));
+describe('Custom Input', () => {
+  describe('with no icons', () => {
+    it('matches the snapshot', () => {
+      const component = render(setupWrapper());
+      expect(component.baseElement).toMatchSnapshot();
+    });
+  });
+
+  describe('with icons', () => {
+    it('matches the snapshot', () => {
+      const component = render(
+        setupWrapper({
+          leftIcon: 'fas fa-address-book',
+          rightIcon: 'fas fa-address-book',
+        })
+      );
+      expect(component.baseElement).toMatchSnapshot();
+    });
+  });
+});

--- a/kafka-ui-react-app/src/components/common/Input/__tests__/__snapshots__/Input.spec.tsx.snap
+++ b/kafka-ui-react-app/src/components/common/Input/__tests__/__snapshots__/Input.spec.tsx.snap
@@ -7,13 +7,13 @@ exports[`Custom Input with icons matches the snapshot 1`] = `
       class="sc-dlfnuX gxtwfA"
     >
       <i
-        class="sc-bdfBQB eaUARU fas fa-address-book"
+        class="sc-bdfBQB gNwdVP fas fa-address-book"
       />
       <input
         class="sc-gsTEea eQzZSW sc-dlfnuX gxtwfA"
       />
       <i
-        class="sc-bdfBQB cVYUOQ fas fa-address-book"
+        class="sc-bdfBQB gJpiMQ fas fa-address-book"
       />
     </div>
   </div>

--- a/kafka-ui-react-app/src/components/common/Input/__tests__/__snapshots__/Input.spec.tsx.snap
+++ b/kafka-ui-react-app/src/components/common/Input/__tests__/__snapshots__/Input.spec.tsx.snap
@@ -4,16 +4,16 @@ exports[`Custom Input with icons matches the snapshot 1`] = `
 <body>
   <div>
     <div
-      style="position: relative;"
+      class="sc-dlfnuX gxtwfA"
     >
       <i
-        class="sc-bdfBQB eVEGAa fas fa-address-book"
+        class="sc-bdfBQB eaUARU fas fa-address-book"
       />
       <input
-        class="sc-gsTEea eQzZSW"
+        class="sc-gsTEea eQzZSW sc-dlfnuX gxtwfA"
       />
       <i
-        class="sc-bdfBQB hWCKJm fas fa-address-book"
+        class="sc-bdfBQB cVYUOQ fas fa-address-book"
       />
     </div>
   </div>
@@ -24,10 +24,10 @@ exports[`Custom Input with no icons matches the snapshot 1`] = `
 <body>
   <div>
     <div
-      style="position: relative;"
+      class="sc-dlfnuX gxtwfA"
     >
       <input
-        class="sc-gsTEea QNjxA"
+        class="sc-gsTEea QNjxA sc-dlfnuX gxtwfA"
       />
     </div>
   </div>

--- a/kafka-ui-react-app/src/components/common/Input/__tests__/__snapshots__/Input.spec.tsx.snap
+++ b/kafka-ui-react-app/src/components/common/Input/__tests__/__snapshots__/Input.spec.tsx.snap
@@ -1,0 +1,35 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Custom Input with icons matches the snapshot 1`] = `
+<body>
+  <div>
+    <div
+      style="position: relative;"
+    >
+      <i
+        class="sc-bdfBQB eVEGAa fas fa-address-book"
+      />
+      <input
+        class="sc-gsTEea eQzZSW"
+      />
+      <i
+        class="sc-bdfBQB hWCKJm fas fa-address-book"
+      />
+    </div>
+  </div>
+</body>
+`;
+
+exports[`Custom Input with no icons matches the snapshot 1`] = `
+<body>
+  <div>
+    <div
+      style="position: relative;"
+    >
+      <input
+        class="sc-gsTEea QNjxA"
+      />
+    </div>
+  </div>
+</body>
+`;

--- a/kafka-ui-react-app/src/components/common/Search/Search.tsx
+++ b/kafka-ui-react-app/src/components/common/Search/Search.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useDebouncedCallback } from 'use-debounce';
+import Input from 'components/common/Input/Input';
 
 interface SearchProps {
   handleSearch: (value: string) => void;
@@ -17,18 +18,13 @@ const Search: React.FC<SearchProps> = ({
     300
   );
   return (
-    <p className="control has-icons-left">
-      <input
-        className="input"
-        type="text"
-        placeholder={placeholder}
-        onChange={onChange}
-        defaultValue={value}
-      />
-      <span className="icon is-small is-left">
-        <i className="fas fa-search" />
-      </span>
-    </p>
+    <Input
+      type="text"
+      placeholder={placeholder}
+      onChange={onChange}
+      defaultValue={value}
+      leftIcon="fas fa-search"
+    />
   );
 };
 

--- a/kafka-ui-react-app/src/components/common/Search/__tests__/Search.spec.tsx
+++ b/kafka-ui-react-app/src/components/common/Search/__tests__/Search.spec.tsx
@@ -1,4 +1,4 @@
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import Search from 'components/common/Search/Search';
 import React from 'react';
 
@@ -8,26 +8,33 @@ jest.mock('use-debounce', () => ({
 
 describe('Search', () => {
   const handleSearch = jest.fn();
-  let component = shallow(
-    <Search
-      handleSearch={handleSearch}
-      value=""
-      placeholder="Search bt the Topic name"
-    />
-  );
   it('calls handleSearch on input', () => {
+    const component = mount(
+      <Search
+        handleSearch={handleSearch}
+        value=""
+        placeholder="Search bt the Topic name"
+      />
+    );
     component.find('input').simulate('change', { target: { value: 'test' } });
     expect(handleSearch).toHaveBeenCalledTimes(1);
   });
 
   describe('when placeholder is provided', () => {
+    const component = shallow(
+      <Search
+        handleSearch={handleSearch}
+        value=""
+        placeholder="Search bt the Topic name"
+      />
+    );
     it('matches the snapshot', () => {
       expect(component).toMatchSnapshot();
     });
   });
 
   describe('when placeholder is not provided', () => {
-    component = shallow(<Search handleSearch={handleSearch} value="" />);
+    const component = shallow(<Search handleSearch={handleSearch} value="" />);
     it('matches the snapshot', () => {
       expect(component).toMatchSnapshot();
     });

--- a/kafka-ui-react-app/src/components/common/Search/__tests__/__snapshots__/Search.spec.tsx.snap
+++ b/kafka-ui-react-app/src/components/common/Search/__tests__/__snapshots__/Search.spec.tsx.snap
@@ -1,43 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Search when placeholder is not provided matches the snapshot 1`] = `
-<p
-  className="control has-icons-left"
->
-  <input
-    className="input"
-    defaultValue=""
-    onChange={[Function]}
-    placeholder="Search"
-    type="text"
-  />
-  <span
-    className="icon is-small is-left"
-  >
-    <i
-      className="fas fa-search"
-    />
-  </span>
-</p>
+<Input
+  defaultValue=""
+  leftIcon="fas fa-search"
+  onChange={[Function]}
+  placeholder="Search"
+  type="text"
+/>
 `;
 
 exports[`Search when placeholder is provided matches the snapshot 1`] = `
-<p
-  className="control has-icons-left"
->
-  <input
-    className="input"
-    defaultValue=""
-    onChange={[Function]}
-    placeholder="Search"
-    type="text"
-  />
-  <span
-    className="icon is-small is-left"
-  >
-    <i
-      className="fas fa-search"
-    />
-  </span>
-</p>
+<Input
+  defaultValue=""
+  leftIcon="fas fa-search"
+  onChange={[Function]}
+  placeholder="Search bt the Topic name"
+  type="text"
+/>
 `;

--- a/kafka-ui-react-app/src/components/common/Search/__tests__/__snapshots__/Search.spec.tsx.snap
+++ b/kafka-ui-react-app/src/components/common/Search/__tests__/__snapshots__/Search.spec.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Search when placeholder is not provided matches the snapshot 1`] = `
-<Input
+<Styled(Input)
   defaultValue=""
   leftIcon="fas fa-search"
   onChange={[Function]}
@@ -11,7 +11,7 @@ exports[`Search when placeholder is not provided matches the snapshot 1`] = `
 `;
 
 exports[`Search when placeholder is provided matches the snapshot 1`] = `
-<Input
+<Styled(Input)
   defaultValue=""
   leftIcon="fas fa-search"
   onChange={[Function]}

--- a/kafka-ui-react-app/src/lib/yupExtended.ts
+++ b/kafka-ui-react-app/src/lib/yupExtended.ts
@@ -1,6 +1,8 @@
 import * as yup from 'yup';
 import { AnyObject, Maybe } from 'yup/lib/types';
 
+import { TOPIC_NAME_VALIDATION_PATTERN } from './constants';
+
 declare module 'yup' {
   interface StringSchema<
     TType extends Maybe<string> = string | undefined,
@@ -39,3 +41,26 @@ const isJsonObject = () => {
 yup.addMethod(yup.string, 'isJsonObject', isJsonObject);
 
 export default yup;
+
+export const topicFormValidationSchema = yup.object().shape({
+  name: yup
+    .string()
+    .required()
+    .matches(
+      TOPIC_NAME_VALIDATION_PATTERN,
+      'Only alphanumeric, _, -, and . allowed'
+    ),
+  partitions: yup.number().required(),
+  replicationFactor: yup.number().required(),
+  minInSyncReplicas: yup.number().required(),
+  cleanupPolicy: yup.string().required(),
+  retentionMs: yup.number().min(-1, 'Must be greater than or equal to -1'),
+  retentionBytes: yup.number(),
+  maxMessageBytes: yup.number().required(),
+  customParams: yup.array().of(
+    yup.object().shape({
+      name: yup.string().required(),
+      value: yup.string().required(),
+    })
+  ),
+});


### PR DESCRIPTION
Created custom inputs. They can either be a part of the react-hook-form or stand-alone inputs. The API is the following:

1. One shouldn't register the Input component in the react-hook-form directly, but rather pass the name and config like that:
```jsx
<Input
  name="name"
  hookFormOptions={{
    required: 'Topic Name is required.',
    pattern: {
      value: TOPIC_NAME_VALIDATION_PATTERN,
      message: 'Only alphanumeric, _, -, and . allowed',
    },
  }}
  placeholder="Topic Name"
  defaultValue={topicName}
/>
```
If we were to register it directly, some of the functionality would break.

2. In order to add icons to the input, one should pass the FA class to the respective prop like this:
```jsx
<Input
  className="input"
  type="number"
  defaultValue="1000012"
  name="maxMessageBytes"
  hookFormOptions={{
    required: 'Maximum message size in bytes is required',
  }}
  leftIcon="fas fa-search"
  rightIcon="fas fa-anchor"
/>
```

3. There are two sizes of the input possible: M and L.