### PR TITLE
Custom select

### DIFF
--- a/kafka-ui-react-app/src/components/Topics/New/__tests__/New.spec.tsx
+++ b/kafka-ui-react-app/src/components/Topics/New/__tests__/New.spec.tsx
@@ -8,6 +8,8 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 import fetchMock from 'fetch-mock-jest';
 import { clusterTopicNewPath, clusterTopicPath } from 'lib/paths';
+import { ThemeProvider } from 'styled-components';
+import theme from 'theme/theme';
 
 const mockStore = configureStore();
 
@@ -26,7 +28,9 @@ describe('New', () => {
   const setupComponent = (history = historyMock, store = storeMock) => (
     <Router history={history}>
       <Provider store={store}>
-        <New />
+        <ThemeProvider theme={theme}>
+          <New />
+        </ThemeProvider>
       </Provider>
     </Router>
   );

--- a/kafka-ui-react-app/src/components/Topics/shared/Form/TopicForm.tsx
+++ b/kafka-ui-react-app/src/components/Topics/shared/Form/TopicForm.tsx
@@ -3,6 +3,7 @@ import { useFormContext } from 'react-hook-form';
 import { TOPIC_NAME_VALIDATION_PATTERN, BYTES_IN_GB } from 'lib/constants';
 import { TopicName, TopicConfigByName } from 'redux/interfaces';
 import { ErrorMessage } from '@hookform/error-message';
+import Select from 'components/common/Select/Select';
 
 import CustomParamsContainer from './CustomParams/CustomParamsContainer';
 import TimeToRetain from './TimeToRetain';
@@ -111,11 +112,11 @@ const TopicForm: React.FC<Props> = ({
         <div className="columns">
           <div className="column is-one-third">
             <label className="label">Cleanup policy</label>
-            <div className="select is-block">
-              <select defaultValue="delete" {...register('cleanupPolicy')}>
+            <div className="is-block">
+              <Select defaultValue="delete" name="cleanupPolicy">
                 <option value="delete">Delete</option>
                 <option value="compact">Compact</option>
-              </select>
+              </Select>
             </div>
           </div>
 
@@ -125,14 +126,14 @@ const TopicForm: React.FC<Props> = ({
 
           <div className="column is-one-third">
             <label className="label">Max size on disk in GB</label>
-            <div className="select is-block">
-              <select defaultValue={-1} {...register('retentionBytes')}>
+            <div className="is-block">
+              <Select defaultValue={-1} name="retentionBytes">
                 <option value={-1}>Not Set</option>
                 <option value={BYTES_IN_GB}>1 GB</option>
                 <option value={BYTES_IN_GB * 10}>10 GB</option>
                 <option value={BYTES_IN_GB * 20}>20 GB</option>
                 <option value={BYTES_IN_GB * 50}>50 GB</option>
-              </select>
+              </Select>
             </div>
           </div>
         </div>

--- a/kafka-ui-react-app/src/components/Topics/shared/Form/TopicForm.tsx
+++ b/kafka-ui-react-app/src/components/Topics/shared/Form/TopicForm.tsx
@@ -127,7 +127,7 @@ const TopicForm: React.FC<Props> = ({
           <div className="column is-one-third">
             <label className="label">Max size on disk in GB</label>
             <div className="is-block">
-              <Select defaultValue={-1} name="retentionBytes">
+              <Select defaultValue={-1} name="retentionBytes" isLive>
                 <option value={-1}>Not Set</option>
                 <option value={BYTES_IN_GB}>1 GB</option>
                 <option value={BYTES_IN_GB * 10}>10 GB</option>

--- a/kafka-ui-react-app/src/components/Topics/shared/Form/TopicForm.tsx
+++ b/kafka-ui-react-app/src/components/Topics/shared/Form/TopicForm.tsx
@@ -127,7 +127,7 @@ const TopicForm: React.FC<Props> = ({
           <div className="column is-one-third">
             <label className="label">Max size on disk in GB</label>
             <div className="is-block">
-              <Select defaultValue={-1} name="retentionBytes" isLive>
+              <Select defaultValue={-1} name="retentionBytes">
                 <option value={-1}>Not Set</option>
                 <option value={BYTES_IN_GB}>1 GB</option>
                 <option value={BYTES_IN_GB * 10}>10 GB</option>

--- a/kafka-ui-react-app/src/components/__tests__/__snapshots__/App.spec.tsx.snap
+++ b/kafka-ui-react-app/src/components/__tests__/__snapshots__/App.spec.tsx.snap
@@ -120,6 +120,20 @@ exports[`App view matches snapshot 1`] = `
                   "normal": "#73848C",
                 },
               },
+              "selectStyles": Object {
+                "borderColor": Object {
+                  "active": "#454F54",
+                  "disabled": "#E3E6E8",
+                  "hover": "#73848C",
+                  "normal": "#ABB5BA",
+                },
+                "color": Object {
+                  "active": "#171A1C",
+                  "disabled": "#ABB5BA",
+                  "hover": "#171A1C",
+                  "normal": "#171A1C",
+                },
+              },
             }
           }
         >

--- a/kafka-ui-react-app/src/components/common/Select/LiveIcon.styled.tsx
+++ b/kafka-ui-react-app/src/components/common/Select/LiveIcon.styled.tsx
@@ -1,0 +1,30 @@
+import styled from 'styled-components';
+import React from 'react';
+
+interface Props {
+  className?: string;
+  selectSize: 'M' | 'L';
+}
+
+const LiveIcon: React.FC<Props> = ({ className }) => {
+  return (
+    <i className={className}>
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 16 16"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <circle cx="8" cy="8" r="7" fill="#FAD1D1" />
+        <circle cx="8" cy="8" r="4" fill="#E61A1A" />
+      </svg>
+    </i>
+  );
+};
+
+export default styled(LiveIcon)`
+  position: absolute;
+  left: 12px;
+  top: ${(props) => (props.selectSize === 'M' ? '8px' : '12px')};
+`;

--- a/kafka-ui-react-app/src/components/common/Select/LiveIcon.styled.tsx
+++ b/kafka-ui-react-app/src/components/common/Select/LiveIcon.styled.tsx
@@ -26,5 +26,6 @@ const LiveIcon: React.FC<Props> = ({ className }) => {
 export default styled(LiveIcon)`
   position: absolute;
   left: 12px;
-  top: ${(props) => (props.selectSize === 'M' ? '8px' : '12px')};
+  top: 50%;
+  transform: translateY(-36%);
 `;

--- a/kafka-ui-react-app/src/components/common/Select/LiveIcon.styled.tsx
+++ b/kafka-ui-react-app/src/components/common/Select/LiveIcon.styled.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 
 interface Props {
   className?: string;
-  selectSize: 'M' | 'L';
 }
 
 const LiveIcon: React.FC<Props> = ({ className }) => {
@@ -27,5 +26,6 @@ export default styled(LiveIcon)`
   position: absolute;
   left: 12px;
   top: 50%;
-  transform: translateY(-36%);
+  transform: translateY(-50%);
+  line-height: 0;
 `;

--- a/kafka-ui-react-app/src/components/common/Select/Select.styled.ts
+++ b/kafka-ui-react-app/src/components/common/Select/Select.styled.ts
@@ -1,0 +1,39 @@
+import styled from 'styled-components';
+
+interface Poprs {
+  selectSize: 'M' | 'L';
+  isLive?: boolean;
+}
+
+const StyledSelect = styled.select<Poprs>`
+  height: ${(props) => (props.selectSize === 'M' ? '32px' : '40px')};
+  border: 1px ${(props) => props.theme.selectStyles.borderColor.normal} solid;
+  border-radius: 4px;
+  font-size: 14px;
+  width: 100%;
+  padding-left: ${(props) => (props.isLive ? '36px' : '12px')};
+  color: ${(props) => props.theme.selectStyles.color.normal};
+
+  background-image: url('data:image/svg+xml,%3Csvg width="10" height="6" viewBox="0 0 10 6" fill="none" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath d="M1 1L5 5L9 1" stroke="%23454F54"/%3E%3C/svg%3E%0A') !important;
+  background-repeat: no-repeat !important;
+  background-position-x: 97% !important;
+  background-position-y: 50% !important;
+  appearance: none !important;
+
+  &:hover {
+    color: ${(props) => props.theme.selectStyles.color.hover};
+    border-color: ${(props) => props.theme.selectStyles.borderColor.hover};
+  }
+  &:focus {
+    outline: none;
+    color: ${(props) => props.theme.selectStyles.color.active};
+    border-color: ${(props) => props.theme.selectStyles.borderColor.active};
+  }
+  &:disabled {
+    color: ${(props) => props.theme.selectStyles.color.disabled};
+    border-color: ${(props) => props.theme.selectStyles.borderColor.disabled};
+    cursor: not-allowed;
+  }
+`;
+
+export default StyledSelect;

--- a/kafka-ui-react-app/src/components/common/Select/Select.tsx
+++ b/kafka-ui-react-app/src/components/common/Select/Select.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { useFormContext, RegisterOptions } from 'react-hook-form';
+
+import LiveIcon from './LiveIcon.styled';
+import StyledSelect from './Select.styled';
+
+interface Props extends React.SelectHTMLAttributes<HTMLSelectElement> {
+  name?: string;
+  hookFormOptions?: RegisterOptions;
+  selectSize?: 'M' | 'L';
+  isLive?: boolean;
+}
+
+const Select: React.FC<Props> = ({
+  children,
+  selectSize,
+  isLive,
+  name,
+  hookFormOptions,
+  ...props
+}) => {
+  const size = selectSize || 'L'; // default size
+  const methods = useFormContext();
+  return (
+    <div
+      style={{
+        position: 'relative',
+      }}
+    >
+      {isLive && <LiveIcon selectSize={size} />}
+      {name ? (
+        <StyledSelect
+          selectSize={size}
+          isLive={isLive}
+          {...methods.register(name, { ...hookFormOptions })}
+          {...props}
+        >
+          {children}
+        </StyledSelect>
+      ) : (
+        <StyledSelect selectSize={size} isLive={isLive} {...props}>
+          {children}
+        </StyledSelect>
+      )}
+    </div>
+  );
+};
+
+export default Select;

--- a/kafka-ui-react-app/src/components/common/Select/Select.tsx
+++ b/kafka-ui-react-app/src/components/common/Select/Select.tsx
@@ -1,36 +1,34 @@
+import { styled } from 'lib/themedStyles';
 import React from 'react';
 import { useFormContext, RegisterOptions } from 'react-hook-form';
 
 import LiveIcon from './LiveIcon.styled';
 import StyledSelect from './Select.styled';
 
-interface Props extends React.SelectHTMLAttributes<HTMLSelectElement> {
+export interface SelectProps
+  extends React.SelectHTMLAttributes<HTMLSelectElement> {
   name?: string;
   hookFormOptions?: RegisterOptions;
   selectSize?: 'M' | 'L';
   isLive?: boolean;
 }
 
-const Select: React.FC<Props> = ({
+const Select: React.FC<SelectProps> = ({
+  className,
   children,
-  selectSize,
+  selectSize = 'L',
   isLive,
   name,
   hookFormOptions,
   ...props
 }) => {
-  const size = selectSize || 'L'; // default size
   const methods = useFormContext();
   return (
-    <div
-      style={{
-        position: 'relative',
-      }}
-    >
-      {isLive && <LiveIcon selectSize={size} />}
+    <div className={className}>
+      {isLive && <LiveIcon selectSize={selectSize} />}
       {name ? (
         <StyledSelect
-          selectSize={size}
+          selectSize={selectSize}
           isLive={isLive}
           {...methods.register(name, { ...hookFormOptions })}
           {...props}
@@ -38,7 +36,7 @@ const Select: React.FC<Props> = ({
           {children}
         </StyledSelect>
       ) : (
-        <StyledSelect selectSize={size} isLive={isLive} {...props}>
+        <StyledSelect selectSize={selectSize} isLive={isLive} {...props}>
           {children}
         </StyledSelect>
       )}
@@ -46,4 +44,6 @@ const Select: React.FC<Props> = ({
   );
 };
 
-export default Select;
+export default styled(Select)`
+  position: relative;
+`;

--- a/kafka-ui-react-app/src/components/common/Select/Select.tsx
+++ b/kafka-ui-react-app/src/components/common/Select/Select.tsx
@@ -23,7 +23,7 @@ const Select: React.FC<SelectProps> = ({
   const methods = useFormContext();
   return (
     <div className={className}>
-      {isLive && <LiveIcon selectSize={selectSize} />}
+      {isLive && <LiveIcon />}
       {name ? (
         <StyledSelect
           selectSize={selectSize}

--- a/kafka-ui-react-app/src/components/common/Select/Select.tsx
+++ b/kafka-ui-react-app/src/components/common/Select/Select.tsx
@@ -1,6 +1,6 @@
 import { styled } from 'lib/themedStyles';
 import React from 'react';
-import { useFormContext, RegisterOptions } from 'react-hook-form';
+import { useFormContext } from 'react-hook-form';
 
 import LiveIcon from './LiveIcon.styled';
 import StyledSelect from './Select.styled';
@@ -8,7 +8,6 @@ import StyledSelect from './Select.styled';
 export interface SelectProps
   extends React.SelectHTMLAttributes<HTMLSelectElement> {
   name?: string;
-  hookFormOptions?: RegisterOptions;
   selectSize?: 'M' | 'L';
   isLive?: boolean;
 }
@@ -19,7 +18,6 @@ const Select: React.FC<SelectProps> = ({
   selectSize = 'L',
   isLive,
   name,
-  hookFormOptions,
   ...props
 }) => {
   const methods = useFormContext();
@@ -30,7 +28,7 @@ const Select: React.FC<SelectProps> = ({
         <StyledSelect
           selectSize={selectSize}
           isLive={isLive}
-          {...methods.register(name, { ...hookFormOptions })}
+          {...methods.register(name)}
           {...props}
         >
           {children}

--- a/kafka-ui-react-app/src/components/common/Select/__tests__/Select.spec.tsx
+++ b/kafka-ui-react-app/src/components/common/Select/__tests__/Select.spec.tsx
@@ -4,16 +4,18 @@ import theme from 'theme/theme';
 import React from 'react';
 import { render } from '@testing-library/react';
 
-const setupWrapper = (props?: Partial<SelectProps>) => (
-  <ThemeProvider theme={theme}>
-    <Select name="test" {...props} />
-  </ThemeProvider>
-);
 jest.mock('react-hook-form', () => ({
   useFormContext: () => ({
     register: jest.fn(),
   }),
 }));
+
+const setupWrapper = (props?: Partial<SelectProps>) => (
+  <ThemeProvider theme={theme}>
+    <Select name="test" {...props} />
+  </ThemeProvider>
+);
+
 describe('Custom Select', () => {
   describe('when non-live', () => {
     it('matches the snapshot', () => {

--- a/kafka-ui-react-app/src/components/common/Select/__tests__/Select.spec.tsx
+++ b/kafka-ui-react-app/src/components/common/Select/__tests__/Select.spec.tsx
@@ -1,0 +1,35 @@
+import Select, { SelectProps } from 'components/common/Select/Select';
+import { ThemeProvider } from 'styled-components';
+import theme from 'theme/theme';
+import React from 'react';
+import { render } from '@testing-library/react';
+
+const setupWrapper = (props?: Partial<SelectProps>) => (
+  <ThemeProvider theme={theme}>
+    <Select name="test" {...props} />
+  </ThemeProvider>
+);
+jest.mock('react-hook-form', () => ({
+  useFormContext: () => ({
+    register: jest.fn(),
+  }),
+}));
+describe('Custom Select', () => {
+  describe('when non-live', () => {
+    it('matches the snapshot', () => {
+      const component = render(setupWrapper());
+      expect(component.baseElement).toMatchSnapshot();
+    });
+  });
+
+  describe('when live', () => {
+    it('matches the snapshot', () => {
+      const component = render(
+        setupWrapper({
+          isLive: true,
+        })
+      );
+      expect(component.baseElement).toMatchSnapshot();
+    });
+  });
+});

--- a/kafka-ui-react-app/src/components/common/Select/__tests__/__snapshots__/Select.spec.tsx.snap
+++ b/kafka-ui-react-app/src/components/common/Select/__tests__/__snapshots__/Select.spec.tsx.snap
@@ -1,0 +1,53 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Custom Select when live matches the snapshot 1`] = `
+<body>
+  <div>
+    <div
+      class="sc-dlfnuX gxtwfA"
+    >
+      <i
+        class="sc-bdfBQB EatPk"
+      >
+        <svg
+          fill="none"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <circle
+            cx="8"
+            cy="8"
+            fill="#FAD1D1"
+            r="7"
+          />
+          <circle
+            cx="8"
+            cy="8"
+            fill="#E61A1A"
+            r="4"
+          />
+        </svg>
+      </i>
+      <select
+        class="sc-gsTEea kUMqVV"
+      />
+    </div>
+  </div>
+</body>
+`;
+
+exports[`Custom Select when non-live matches the snapshot 1`] = `
+<body>
+  <div>
+    <div
+      class="sc-dlfnuX gxtwfA"
+    >
+      <select
+        class="sc-gsTEea hLKjxb"
+      />
+    </div>
+  </div>
+</body>
+`;

--- a/kafka-ui-react-app/src/components/common/Select/__tests__/__snapshots__/Select.spec.tsx.snap
+++ b/kafka-ui-react-app/src/components/common/Select/__tests__/__snapshots__/Select.spec.tsx.snap
@@ -7,7 +7,7 @@ exports[`Custom Select when live matches the snapshot 1`] = `
       class="sc-dlfnuX gxtwfA"
     >
       <i
-        class="sc-bdfBQB EatPk"
+        class="sc-bdfBQB ldVUdn"
       >
         <svg
           fill="none"

--- a/kafka-ui-react-app/src/theme/theme.ts
+++ b/kafka-ui-react-app/src/theme/theme.ts
@@ -100,6 +100,20 @@ const theme = {
       active: Colors.neutral[90],
     },
   },
+  selectStyles: {
+    color: {
+      normal: Colors.neutral[90],
+      hover: Colors.neutral[90],
+      active: Colors.neutral[90],
+      disabled: Colors.neutral[30],
+    },
+    borderColor: {
+      normal: Colors.neutral[30],
+      hover: Colors.neutral[50],
+      active: Colors.neutral[70],
+      disabled: Colors.neutral[10],
+    },
+  },
 };
 
 export default theme;


### PR DESCRIPTION
Custom selects. The API is similar to inputs: 
 1. Provide `name` to register it in the react-hook-form, although the validation must be done through an external resolver.
 2. There are two sizes - M and L
 3. Pass the `isLive` prop to add this red dot on the left to indicate that the change of the select will have an immediate effect.
