### PR TITLE
Unnecessary casting removed from AvroFormatter to fix primitive values deserialization

### DIFF
--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/serde/schemaregistry/AvroMessageFormatter.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/serde/schemaregistry/AvroMessageFormatter.java
@@ -4,7 +4,6 @@ import io.confluent.kafka.schemaregistry.avro.AvroSchemaUtils;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.serializers.KafkaAvroDeserializer;
 import lombok.SneakyThrows;
-import org.apache.avro.generic.GenericRecord;
 
 public class AvroMessageFormatter implements MessageFormatter {
   private final KafkaAvroDeserializer avroDeserializer;
@@ -16,8 +15,8 @@ public class AvroMessageFormatter implements MessageFormatter {
   @Override
   @SneakyThrows
   public String format(String topic, byte[] value) {
-    GenericRecord avroRecord = (GenericRecord) avroDeserializer.deserialize(topic, value);
-    byte[] jsonBytes = AvroSchemaUtils.toJson(avroRecord);
+    Object deserialized = avroDeserializer.deserialize(topic, value);
+    byte[] jsonBytes = AvroSchemaUtils.toJson(deserialized);
     return new String(jsonBytes);
   }
 

--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/serde/schemaregistry/AvroMessageFormatter.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/serde/schemaregistry/AvroMessageFormatter.java
@@ -15,6 +15,8 @@ public class AvroMessageFormatter implements MessageFormatter {
   @Override
   @SneakyThrows
   public String format(String topic, byte[] value) {
+    // deserialized will have type, that depends on schema type (record or primitive),
+    // AvroSchemaUtils.toJson(...) method will take it into account
     Object deserialized = avroDeserializer.deserialize(topic, value);
     byte[] jsonBytes = AvroSchemaUtils.toJson(deserialized);
     return new String(jsonBytes);

--- a/kafka-ui-api/src/test/java/com/provectus/kafka/ui/service/SendAndReadTests.java
+++ b/kafka-ui-api/src/test/java/com/provectus/kafka/ui/service/SendAndReadTests.java
@@ -65,17 +65,12 @@ public class SendAndReadTests extends AbstractBaseTest {
           + "}"
   );
 
-  private static final AvroSchema AVRO_SCHEMA_PRIMITIVE_STRING = new AvroSchema(
-      "{"
-          + "  \"type\": \"string\""
-          + "}"
-  );
+  private static final AvroSchema AVRO_SCHEMA_PRIMITIVE_STRING =
+      new AvroSchema("{ \"type\": \"string\" }");
 
-  private static final AvroSchema AVRO_SCHEMA_PRIMITIVE_INT = new AvroSchema(
-      "{"
-          + "  \"type\": \"int\""
-          + "}"
-  );
+  private static final AvroSchema AVRO_SCHEMA_PRIMITIVE_INT =
+      new AvroSchema("{ \"type\": \"int\" }");
+
 
   private static final String AVRO_SCHEMA_1_JSON_RECORD
       = "{ \"field1\":\"testStr\", \"field2\": 123 }";

--- a/kafka-ui-api/src/test/java/com/provectus/kafka/ui/service/SendAndReadTests.java
+++ b/kafka-ui-api/src/test/java/com/provectus/kafka/ui/service/SendAndReadTests.java
@@ -65,6 +65,18 @@ public class SendAndReadTests extends AbstractBaseTest {
           + "}"
   );
 
+  private static final AvroSchema AVRO_SCHEMA_PRIMITIVE_STRING = new AvroSchema(
+      "{"
+          + "  \"type\": \"string\""
+          + "}"
+  );
+
+  private static final AvroSchema AVRO_SCHEMA_PRIMITIVE_INT = new AvroSchema(
+      "{"
+          + "  \"type\": \"int\""
+          + "}"
+  );
+
   private static final String AVRO_SCHEMA_1_JSON_RECORD
       = "{ \"field1\":\"testStr\", \"field2\": 123 }";
 
@@ -184,6 +196,22 @@ public class SendAndReadTests extends AbstractBaseTest {
         .doAssert(polled -> {
           assertThat(polled.getKey()).isEqualTo("testKey");
           assertThat(polled.getContent()).isNull();
+        });
+  }
+
+  @Test
+  void privimiveAvroSchema() {
+    new SendAndReadSpec()
+        .withKeySchema(AVRO_SCHEMA_PRIMITIVE_STRING)
+        .withValueSchema(AVRO_SCHEMA_PRIMITIVE_INT)
+        .withMsgToSend(
+            new CreateTopicMessage()
+                .key("\"some string\"")
+                .content("123")
+        )
+        .doAssert(polled -> {
+          assertThat(polled.getKey()).isEqualTo("\"some string\"");
+          assertThat(polled.getContent()).isEqualTo("123");
         });
   }
 

--- a/kafka-ui-api/src/test/java/com/provectus/kafka/ui/service/SendAndReadTests.java
+++ b/kafka-ui-api/src/test/java/com/provectus/kafka/ui/service/SendAndReadTests.java
@@ -200,7 +200,7 @@ public class SendAndReadTests extends AbstractBaseTest {
   }
 
   @Test
-  void privimiveAvroSchema() {
+  void primitiveAvroSchemas() {
     new SendAndReadSpec()
         .withKeySchema(AVRO_SCHEMA_PRIMITIVE_STRING)
         .withValueSchema(AVRO_SCHEMA_PRIMITIVE_INT)


### PR DESCRIPTION
KafkaAvroDeserializer returns GenerericRecord only if schema has "record" type, in case of primitive types it will return corresponding java object.

<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing applications:)
<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)

**Is there anything you'd like reviewers to focus on?**


**How Has This Been Tested?** (put an "X" next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [ ] Manually(please, describe, when necessary)
- [x] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "X" next to an item, otherwise PR will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings(e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/provectus/kafka-ui/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/provectus/kafka-ui/blob/master/CODE-OF-CONDUCT.md)