### PR TITLE
Fix Metrics

### DIFF
--- a/kafka-ui-react-app/src/components/Brokers/Brokers.tsx
+++ b/kafka-ui-react-app/src/components/Brokers/Brokers.tsx
@@ -7,6 +7,7 @@ import MetricsWrapper from 'components/common/Dashboard/MetricsWrapper';
 import Indicator from 'components/common/Dashboard/Indicator';
 import BytesFormatted from 'components/common/BytesFormatted/BytesFormatted';
 import { useParams } from 'react-router';
+import TagStyled from 'components/common/Tag/Tag.styled';
 
 interface Props extends ClusterStats {
   isFetched: boolean;
@@ -42,65 +43,69 @@ const Brokers: React.FC<Props> = ({
   const zkOnline = zooKeeperStatus === ZooKeeperStatus.online;
 
   return (
-    <div className="section">
-      <div className="metrics-box mb-2">
-        <MetricsWrapper title="Uptime" wrapperClassName="is-flex-grow-1">
-          <Indicator className="is-one-third" label="Total Brokers">
-            {brokerCount}
-          </Indicator>
-          <Indicator className="is-one-third" label="Active Controllers">
-            {activeControllers}
-          </Indicator>
-          <Indicator className="is-one-third" label="Zookeeper Status">
-            <span className={cx('tag', zkOnline ? 'is-success' : 'is-danger')}>
-              {zkOnline ? 'Online' : 'Offline'}
-            </span>
-          </Indicator>
-          <Indicator className="is-one-third" label="Version">
-            {version}
-          </Indicator>
-        </MetricsWrapper>
-        <MetricsWrapper title="Partitions" wrapperClassName="is-flex-grow-1">
-          <Indicator label="Online">
-            <span
-              className={cx({ 'has-text-danger': offlinePartitionCount !== 0 })}
-            >
-              {onlinePartitionCount}
-            </span>
-            <span className="has-text-weight-light">
-              {' '}
-              of {(onlinePartitionCount || 0) + (offlinePartitionCount || 0)}
-            </span>
-          </Indicator>
-          <Indicator label="URP" title="Under replicated partitions">
-            {underReplicatedPartitionCount}
-          </Indicator>
-          <Indicator label="In Sync Replicas">{inSyncReplicasCount}</Indicator>
-          <Indicator label="Out of Sync Replicas">
-            {outOfSyncReplicasCount}
-          </Indicator>
-        </MetricsWrapper>
-        <MetricsWrapper
-          multiline
-          title="Disk Usage"
-          wrapperClassName="is-flex-grow-1"
-        >
-          {diskUsage?.map((brokerDiskUsage) => (
-            <React.Fragment key={brokerDiskUsage.brokerId}>
-              <Indicator className="is-one-third" label="Broker">
-                {brokerDiskUsage.brokerId}
-              </Indicator>
-              <Indicator className="is-one-third" label="Segment Size" title="">
-                <BytesFormatted value={brokerDiskUsage.segmentSize} />
-              </Indicator>
-              <Indicator className="is-one-third" label="Segment count">
-                {brokerDiskUsage.segmentCount}
-              </Indicator>
-            </React.Fragment>
-          ))}
-        </MetricsWrapper>
+    <>
+      <div className="section">
+        <div className="metrics-box mb-2 is-flex">
+          <MetricsWrapper title="Uptime">
+            <Indicator label="Total Brokers">{brokerCount}</Indicator>
+            <Indicator label="Active Controllers">
+              {activeControllers}
+            </Indicator>
+            <Indicator label="Zookeeper Status">
+              <TagStyled
+                text={zkOnline ? 'online' : 'offline'}
+                color={zkOnline ? 'green' : 'gray'}
+              />
+            </Indicator>
+            <Indicator label="Version">{version}</Indicator>
+          </MetricsWrapper>
+          <MetricsWrapper title="Partitions">
+            <Indicator label="Online">
+              <span
+                className={cx({
+                  'has-text-danger': offlinePartitionCount !== 0,
+                })}
+              >
+                {onlinePartitionCount}
+              </span>
+              <span className="has-text-weight-light">
+                {' '}
+                of {(onlinePartitionCount || 0) + (offlinePartitionCount || 0)}
+              </span>
+            </Indicator>
+            <Indicator label="URP" title="Under replicated partitions">
+              {underReplicatedPartitionCount}
+            </Indicator>
+            <Indicator label="In Sync Replicas">
+              {inSyncReplicasCount}
+            </Indicator>
+            <Indicator label="Out of Sync Replicas">
+              {outOfSyncReplicasCount}
+            </Indicator>
+          </MetricsWrapper>
+        </div>
       </div>
-    </div>
+      <table className="table is-fullwidth">
+        <thead>
+          <tr>
+            <th>Broker</th>
+            <th>Segment size (Mb)</th>
+            <th>Segment Count</th>
+          </tr>
+        </thead>
+        <tbody>
+          {diskUsage?.map((brokerDiskUsage) => (
+            <tr key={brokerDiskUsage.brokerId}>
+              <td>{brokerDiskUsage.brokerId}</td>
+              <td>
+                <BytesFormatted value={brokerDiskUsage.segmentSize} />
+              </td>
+              <td>{brokerDiskUsage.segmentCount}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </>
   );
 };
 

--- a/kafka-ui-react-app/src/components/Brokers/__test__/Brokers.spec.tsx
+++ b/kafka-ui-react-app/src/components/Brokers/__test__/Brokers.spec.tsx
@@ -4,6 +4,8 @@ import Brokers from 'components/Brokers/Brokers';
 import { ClusterName } from 'redux/interfaces';
 import { StaticRouter } from 'react-router';
 import { ClusterStats } from 'generated-sources';
+import { ThemeProvider } from 'styled-components';
+import theme from 'theme/theme';
 
 interface Props extends ClusterStats {
   isFetched: boolean;
@@ -17,32 +19,29 @@ describe('Brokers Component', () => {
   describe('Brokers Empty', () => {
     const setupEmptyComponent = (props: Partial<Props> = {}) => (
       <StaticRouter location={{ pathname }} context={{}}>
-        <Brokers
-          brokerCount={0}
-          activeControllers={0}
-          zooKeeperStatus={0}
-          onlinePartitionCount={0}
-          offlinePartitionCount={0}
-          inSyncReplicasCount={0}
-          outOfSyncReplicasCount={0}
-          underReplicatedPartitionCount={0}
-          version="1"
-          fetchClusterStats={jest.fn()}
-          fetchBrokers={jest.fn()}
-          diskUsage={undefined}
-          isFetched={false}
-          {...props}
-        />
+        <ThemeProvider theme={theme}>
+          <Brokers
+            brokerCount={0}
+            activeControllers={0}
+            zooKeeperStatus={0}
+            onlinePartitionCount={0}
+            offlinePartitionCount={0}
+            inSyncReplicasCount={0}
+            outOfSyncReplicasCount={0}
+            underReplicatedPartitionCount={0}
+            version="1"
+            fetchClusterStats={jest.fn()}
+            fetchBrokers={jest.fn()}
+            diskUsage={undefined}
+            isFetched={false}
+            {...props}
+          />
+        </ThemeProvider>
       </StaticRouter>
     );
     it('renders section', () => {
       const component = mount(setupEmptyComponent());
       expect(component.exists('.section')).toBeTruthy();
-    });
-
-    it('renders section with is-danger selector', () => {
-      const component = mount(setupEmptyComponent());
-      expect(component.exists('.is-danger')).toBeTruthy();
     });
 
     it('matches Brokers Empty snapshot', () => {
@@ -53,35 +52,32 @@ describe('Brokers Component', () => {
   describe('Brokers', () => {
     const setupComponent = (props: Partial<Props> = {}) => (
       <StaticRouter location={{ pathname }} context={{}}>
-        <Brokers
-          brokerCount={1}
-          activeControllers={1}
-          zooKeeperStatus={1}
-          onlinePartitionCount={64}
-          offlinePartitionCount={0}
-          inSyncReplicasCount={64}
-          outOfSyncReplicasCount={0}
-          underReplicatedPartitionCount={0}
-          version="1"
-          fetchClusterStats={jest.fn()}
-          fetchBrokers={jest.fn()}
-          diskUsage={[
-            {
-              brokerId: 1,
-              segmentCount: 64,
-              segmentSize: 60718,
-            },
-          ]}
-          isFetched
-          {...props}
-        />
+        <ThemeProvider theme={theme}>
+          <Brokers
+            brokerCount={1}
+            activeControllers={1}
+            zooKeeperStatus={1}
+            onlinePartitionCount={64}
+            offlinePartitionCount={0}
+            inSyncReplicasCount={64}
+            outOfSyncReplicasCount={0}
+            underReplicatedPartitionCount={0}
+            version="1"
+            fetchClusterStats={jest.fn()}
+            fetchBrokers={jest.fn()}
+            diskUsage={[
+              {
+                brokerId: 1,
+                segmentCount: 64,
+                segmentSize: 60718,
+              },
+            ]}
+            isFetched
+            {...props}
+          />
+        </ThemeProvider>
       </StaticRouter>
     );
-
-    it('renders section with is-success selector', () => {
-      const component = mount(setupComponent());
-      expect(component.exists('.is-success')).toBeTruthy();
-    });
 
     it('matches snapshot', () => {
       expect(mount(setupComponent())).toMatchSnapshot();

--- a/kafka-ui-react-app/src/components/Brokers/__test__/__snapshots__/Brokers.spec.tsx.snap
+++ b/kafka-ui-react-app/src/components/Brokers/__test__/__snapshots__/Brokers.spec.tsx.snap
@@ -30,305 +30,410 @@ exports[`Brokers Component Brokers Empty matches Brokers Empty snapshot 1`] = `
     }
     staticContext={Object {}}
   >
-    <Brokers
-      activeControllers={0}
-      brokerCount={0}
-      fetchBrokers={
-        [MockFunction] {
-          "calls": Array [
-            Array [
-              undefined,
-            ],
-          ],
-          "results": Array [
-            Object {
-              "type": "return",
-              "value": undefined,
+    <Component
+      theme={
+        Object {
+          "buttonStyles": Object {
+            "fontSize": Object {
+              "L": "16px",
+              "M": "14px",
+              "S": "14px",
             },
-          ],
+            "height": Object {
+              "L": "40px",
+              "M": "32px",
+              "S": "24px",
+            },
+            "primary": Object {
+              "backgroundColor": Object {
+                "active": "#1414B8",
+                "hover": "#1717CF",
+                "normal": "#4F4FFF",
+              },
+              "color": "#FFFFFF",
+              "invertedColors": Object {
+                "active": "#1414B8",
+                "hover": "#1717CF",
+                "normal": "#4F4FFF",
+              },
+            },
+            "secondary": Object {
+              "backgroundColor": Object {
+                "active": "#D5DADD",
+                "hover": "#E3E6E8",
+                "normal": "#F1F2F3",
+              },
+              "color": "#171A1C",
+              "invertedColors": Object {
+                "active": "#171A1C",
+                "hover": "#454F54",
+                "normal": "#73848C",
+              },
+            },
+          },
+          "liStyles": Object {
+            "primary": Object {
+              "backgroundColor": Object {
+                "active": "#E3E6E8",
+                "hover": "#F1F2F3",
+                "normal": "#FFFFFF",
+              },
+              "color": Object {
+                "active": "#171A1C",
+                "hover": "#F1F2F3",
+                "normal": "#73848C",
+              },
+            },
+          },
+          "secondaryTabStyles": Object {
+            "backgroundColor": Object {
+              "active": "#E3E6E8",
+              "hover": "#F1F2F3",
+              "normal": "#FFFFFF",
+            },
+            "color": Object {
+              "active": "#171A1C",
+              "hover": "#171A1C",
+              "normal": "#73848C",
+            },
+          },
+          "selectStyles": Object {
+            "borderColor": Object {
+              "active": "#454F54",
+              "disabled": "#E3E6E8",
+              "hover": "#73848C",
+              "normal": "#ABB5BA",
+            },
+            "color": Object {
+              "active": "#171A1C",
+              "disabled": "#ABB5BA",
+              "hover": "#171A1C",
+              "normal": "#171A1C",
+            },
+          },
+          "tagStyles": Object {
+            "backgroundColor": Object {
+              "gray": "#E3E6E8",
+              "green": "#D6F5E0",
+              "yellow": "#FFEECC",
+            },
+            "color": "#171A1C",
+          },
         }
       }
-      fetchClusterStats={
-        [MockFunction] {
-          "calls": Array [
-            Array [
-              undefined,
-            ],
-          ],
-          "results": Array [
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-          ],
-        }
-      }
-      inSyncReplicasCount={0}
-      isFetched={false}
-      offlinePartitionCount={0}
-      onlinePartitionCount={0}
-      outOfSyncReplicasCount={0}
-      underReplicatedPartitionCount={0}
-      version="1"
-      zooKeeperStatus={0}
     >
-      <div
-        className="section"
+      <Brokers
+        activeControllers={0}
+        brokerCount={0}
+        fetchBrokers={
+          [MockFunction] {
+            "calls": Array [
+              Array [
+                undefined,
+              ],
+            ],
+            "results": Array [
+              Object {
+                "type": "return",
+                "value": undefined,
+              },
+            ],
+          }
+        }
+        fetchClusterStats={
+          [MockFunction] {
+            "calls": Array [
+              Array [
+                undefined,
+              ],
+            ],
+            "results": Array [
+              Object {
+                "type": "return",
+                "value": undefined,
+              },
+            ],
+          }
+        }
+        inSyncReplicasCount={0}
+        isFetched={false}
+        offlinePartitionCount={0}
+        onlinePartitionCount={0}
+        outOfSyncReplicasCount={0}
+        underReplicatedPartitionCount={0}
+        version="1"
+        zooKeeperStatus={0}
       >
         <div
-          className="metrics-box mb-2"
+          className="section"
         >
-          <MetricsWrapper
-            title="Uptime"
-            wrapperClassName="is-flex-grow-1"
+          <div
+            className="metrics-box mb-2 is-flex"
           >
-            <div
-              className="is-flex-grow-1"
+            <Styled(MetricsWrapper)
+              title="Uptime"
             >
-              <h5
-                className="is-7 has-text-weight-medium mb-2"
-              >
-                Uptime
-              </h5>
-              <div
-                className="box"
+              <MetricsWrapper
+                className="sc-bdfBQB ewAWCQ"
+                title="Uptime"
               >
                 <div
-                  className="level"
+                  className="sc-bdfBQB ewAWCQ"
                 >
-                  <Indicator
-                    className="is-one-third"
-                    label="Total Brokers"
+                  <h5
+                    className="is-7 has-text-weight-medium mb-2"
                   >
-                    <div
-                      className="level-item is-one-third"
-                    >
-                      <div>
-                        <p
-                          className="is-size-8"
-                        >
-                          Total Brokers
-                        </p>
-                        <p
-                          className="is-size-6 has-text-weight-medium"
-                        >
-                          0
-                        </p>
-                      </div>
-                    </div>
-                  </Indicator>
-                  <Indicator
-                    className="is-one-third"
-                    label="Active Controllers"
+                    Uptime
+                  </h5>
+                  <div
+                    className="indicatorsWrapper"
                   >
-                    <div
-                      className="level-item is-one-third"
+                    <Styled(Indicator)
+                      label="Total Brokers"
                     >
-                      <div>
-                        <p
-                          className="is-size-8"
+                      <Indicator
+                        className="sc-gsTEea fGiIVV"
+                        label="Total Brokers"
+                      >
+                        <div
+                          className="sc-gsTEea fGiIVV"
                         >
-                          Active Controllers
-                        </p>
-                        <p
-                          className="is-size-6 has-text-weight-medium"
-                        >
-                          0
-                        </p>
-                      </div>
-                    </div>
-                  </Indicator>
-                  <Indicator
-                    className="is-one-third"
-                    label="Zookeeper Status"
-                  >
-                    <div
-                      className="level-item is-one-third"
+                          <div>
+                            <p
+                              className="is-size-8"
+                            >
+                              Total Brokers
+                            </p>
+                            0
+                          </div>
+                        </div>
+                      </Indicator>
+                    </Styled(Indicator)>
+                    <Styled(Indicator)
+                      label="Active Controllers"
                     >
-                      <div>
-                        <p
-                          className="is-size-8"
+                      <Indicator
+                        className="sc-gsTEea fGiIVV"
+                        label="Active Controllers"
+                      >
+                        <div
+                          className="sc-gsTEea fGiIVV"
                         >
-                          Zookeeper Status
-                        </p>
-                        <p
-                          className="is-size-6 has-text-weight-medium"
-                        >
-                          <span
-                            className="tag is-danger"
-                          >
-                            Offline
-                          </span>
-                        </p>
-                      </div>
-                    </div>
-                  </Indicator>
-                  <Indicator
-                    className="is-one-third"
-                    label="Version"
-                  >
-                    <div
-                      className="level-item is-one-third"
+                          <div>
+                            <p
+                              className="is-size-8"
+                            >
+                              Active Controllers
+                            </p>
+                            0
+                          </div>
+                        </div>
+                      </Indicator>
+                    </Styled(Indicator)>
+                    <Styled(Indicator)
+                      label="Zookeeper Status"
                     >
-                      <div>
-                        <p
-                          className="is-size-8"
+                      <Indicator
+                        className="sc-gsTEea fGiIVV"
+                        label="Zookeeper Status"
+                      >
+                        <div
+                          className="sc-gsTEea fGiIVV"
                         >
-                          Version
-                        </p>
-                        <p
-                          className="is-size-6 has-text-weight-medium"
+                          <div>
+                            <p
+                              className="is-size-8"
+                            >
+                              Zookeeper Status
+                            </p>
+                            <Styled(Tag)
+                              color="gray"
+                              text="offline"
+                            >
+                              <Tag
+                                className="sc-dlfnuX gBFAcb"
+                                color="gray"
+                                text="offline"
+                              >
+                                <p
+                                  className="sc-dlfnuX gBFAcb"
+                                >
+                                  offline
+                                </p>
+                              </Tag>
+                            </Styled(Tag)>
+                          </div>
+                        </div>
+                      </Indicator>
+                    </Styled(Indicator)>
+                    <Styled(Indicator)
+                      label="Version"
+                    >
+                      <Indicator
+                        className="sc-gsTEea fGiIVV"
+                        label="Version"
+                      >
+                        <div
+                          className="sc-gsTEea fGiIVV"
                         >
-                          1
-                        </p>
-                      </div>
-                    </div>
-                  </Indicator>
+                          <div>
+                            <p
+                              className="is-size-8"
+                            >
+                              Version
+                            </p>
+                            1
+                          </div>
+                        </div>
+                      </Indicator>
+                    </Styled(Indicator)>
+                  </div>
                 </div>
-              </div>
-            </div>
-          </MetricsWrapper>
-          <MetricsWrapper
-            title="Partitions"
-            wrapperClassName="is-flex-grow-1"
-          >
-            <div
-              className="is-flex-grow-1"
+              </MetricsWrapper>
+            </Styled(MetricsWrapper)>
+            <Styled(MetricsWrapper)
+              title="Partitions"
             >
-              <h5
-                className="is-7 has-text-weight-medium mb-2"
-              >
-                Partitions
-              </h5>
-              <div
-                className="box"
+              <MetricsWrapper
+                className="sc-bdfBQB ewAWCQ"
+                title="Partitions"
               >
                 <div
-                  className="level"
+                  className="sc-bdfBQB ewAWCQ"
                 >
-                  <Indicator
-                    label="Online"
+                  <h5
+                    className="is-7 has-text-weight-medium mb-2"
                   >
-                    <div
-                      className="level-item"
-                    >
-                      <div>
-                        <p
-                          className="is-size-8"
-                        >
-                          Online
-                        </p>
-                        <p
-                          className="is-size-6 has-text-weight-medium"
-                        >
-                          <span
-                            className=""
-                          >
-                            0
-                          </span>
-                          <span
-                            className="has-text-weight-light"
-                          >
-                             
-                            of 
-                            0
-                          </span>
-                        </p>
-                      </div>
-                    </div>
-                  </Indicator>
-                  <Indicator
-                    label="URP"
-                    title="Under replicated partitions"
+                    Partitions
+                  </h5>
+                  <div
+                    className="indicatorsWrapper"
                   >
-                    <div
-                      className="level-item"
+                    <Styled(Indicator)
+                      label="Online"
                     >
-                      <div
+                      <Indicator
+                        className="sc-gsTEea fGiIVV"
+                        label="Online"
+                      >
+                        <div
+                          className="sc-gsTEea fGiIVV"
+                        >
+                          <div>
+                            <p
+                              className="is-size-8"
+                            >
+                              Online
+                            </p>
+                            <span
+                              className=""
+                            >
+                              0
+                            </span>
+                            <span
+                              className="has-text-weight-light"
+                            >
+                               
+                              of 
+                              0
+                            </span>
+                          </div>
+                        </div>
+                      </Indicator>
+                    </Styled(Indicator)>
+                    <Styled(Indicator)
+                      label="URP"
+                      title="Under replicated partitions"
+                    >
+                      <Indicator
+                        className="sc-gsTEea fGiIVV"
+                        label="URP"
                         title="Under replicated partitions"
                       >
-                        <p
-                          className="is-size-8"
+                        <div
+                          className="sc-gsTEea fGiIVV"
                         >
-                          URP
-                        </p>
-                        <p
-                          className="is-size-6 has-text-weight-medium"
-                        >
-                          0
-                        </p>
-                      </div>
-                    </div>
-                  </Indicator>
-                  <Indicator
-                    label="In Sync Replicas"
-                  >
-                    <div
-                      className="level-item"
+                          <div
+                            title="Under replicated partitions"
+                          >
+                            <p
+                              className="is-size-8"
+                            >
+                              URP
+                            </p>
+                            0
+                          </div>
+                        </div>
+                      </Indicator>
+                    </Styled(Indicator)>
+                    <Styled(Indicator)
+                      label="In Sync Replicas"
                     >
-                      <div>
-                        <p
-                          className="is-size-8"
+                      <Indicator
+                        className="sc-gsTEea fGiIVV"
+                        label="In Sync Replicas"
+                      >
+                        <div
+                          className="sc-gsTEea fGiIVV"
                         >
-                          In Sync Replicas
-                        </p>
-                        <p
-                          className="is-size-6 has-text-weight-medium"
-                        >
-                          0
-                        </p>
-                      </div>
-                    </div>
-                  </Indicator>
-                  <Indicator
-                    label="Out of Sync Replicas"
-                  >
-                    <div
-                      className="level-item"
+                          <div>
+                            <p
+                              className="is-size-8"
+                            >
+                              In Sync Replicas
+                            </p>
+                            0
+                          </div>
+                        </div>
+                      </Indicator>
+                    </Styled(Indicator)>
+                    <Styled(Indicator)
+                      label="Out of Sync Replicas"
                     >
-                      <div>
-                        <p
-                          className="is-size-8"
+                      <Indicator
+                        className="sc-gsTEea fGiIVV"
+                        label="Out of Sync Replicas"
+                      >
+                        <div
+                          className="sc-gsTEea fGiIVV"
                         >
-                          Out of Sync Replicas
-                        </p>
-                        <p
-                          className="is-size-6 has-text-weight-medium"
-                        >
-                          0
-                        </p>
-                      </div>
-                    </div>
-                  </Indicator>
+                          <div>
+                            <p
+                              className="is-size-8"
+                            >
+                              Out of Sync Replicas
+                            </p>
+                            0
+                          </div>
+                        </div>
+                      </Indicator>
+                    </Styled(Indicator)>
+                  </div>
                 </div>
-              </div>
-            </div>
-          </MetricsWrapper>
-          <MetricsWrapper
-            multiline={true}
-            title="Disk Usage"
-            wrapperClassName="is-flex-grow-1"
-          >
-            <div
-              className="is-flex-grow-1"
-            >
-              <h5
-                className="is-7 has-text-weight-medium mb-2"
-              >
-                Disk Usage
-              </h5>
-              <div
-                className="box"
-              >
-                <div
-                  className="level level-multiline"
-                />
-              </div>
-            </div>
-          </MetricsWrapper>
+              </MetricsWrapper>
+            </Styled(MetricsWrapper)>
+          </div>
         </div>
-      </div>
-    </Brokers>
+        <table
+          className="table is-fullwidth"
+        >
+          <thead>
+            <tr>
+              <th>
+                Broker
+              </th>
+              <th>
+                Segment size (Mb)
+              </th>
+              <th>
+                Segment Count
+              </th>
+            </tr>
+          </thead>
+          <tbody />
+        </table>
+      </Brokers>
+    </Component>
   </Router>
 </StaticRouter>
 `;
@@ -363,387 +468,439 @@ exports[`Brokers Component Brokers matches snapshot 1`] = `
     }
     staticContext={Object {}}
   >
-    <Brokers
-      activeControllers={1}
-      brokerCount={1}
-      diskUsage={
-        Array [
-          Object {
-            "brokerId": 1,
-            "segmentCount": 64,
-            "segmentSize": 60718,
+    <Component
+      theme={
+        Object {
+          "buttonStyles": Object {
+            "fontSize": Object {
+              "L": "16px",
+              "M": "14px",
+              "S": "14px",
+            },
+            "height": Object {
+              "L": "40px",
+              "M": "32px",
+              "S": "24px",
+            },
+            "primary": Object {
+              "backgroundColor": Object {
+                "active": "#1414B8",
+                "hover": "#1717CF",
+                "normal": "#4F4FFF",
+              },
+              "color": "#FFFFFF",
+              "invertedColors": Object {
+                "active": "#1414B8",
+                "hover": "#1717CF",
+                "normal": "#4F4FFF",
+              },
+            },
+            "secondary": Object {
+              "backgroundColor": Object {
+                "active": "#D5DADD",
+                "hover": "#E3E6E8",
+                "normal": "#F1F2F3",
+              },
+              "color": "#171A1C",
+              "invertedColors": Object {
+                "active": "#171A1C",
+                "hover": "#454F54",
+                "normal": "#73848C",
+              },
+            },
           },
-        ]
-      }
-      fetchBrokers={
-        [MockFunction] {
-          "calls": Array [
-            Array [
-              undefined,
-            ],
-          ],
-          "results": Array [
-            Object {
-              "type": "return",
-              "value": undefined,
+          "liStyles": Object {
+            "primary": Object {
+              "backgroundColor": Object {
+                "active": "#E3E6E8",
+                "hover": "#F1F2F3",
+                "normal": "#FFFFFF",
+              },
+              "color": Object {
+                "active": "#171A1C",
+                "hover": "#F1F2F3",
+                "normal": "#73848C",
+              },
             },
-          ],
+          },
+          "secondaryTabStyles": Object {
+            "backgroundColor": Object {
+              "active": "#E3E6E8",
+              "hover": "#F1F2F3",
+              "normal": "#FFFFFF",
+            },
+            "color": Object {
+              "active": "#171A1C",
+              "hover": "#171A1C",
+              "normal": "#73848C",
+            },
+          },
+          "selectStyles": Object {
+            "borderColor": Object {
+              "active": "#454F54",
+              "disabled": "#E3E6E8",
+              "hover": "#73848C",
+              "normal": "#ABB5BA",
+            },
+            "color": Object {
+              "active": "#171A1C",
+              "disabled": "#ABB5BA",
+              "hover": "#171A1C",
+              "normal": "#171A1C",
+            },
+          },
+          "tagStyles": Object {
+            "backgroundColor": Object {
+              "gray": "#E3E6E8",
+              "green": "#D6F5E0",
+              "yellow": "#FFEECC",
+            },
+            "color": "#171A1C",
+          },
         }
       }
-      fetchClusterStats={
-        [MockFunction] {
-          "calls": Array [
-            Array [
-              undefined,
-            ],
-          ],
-          "results": Array [
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-          ],
-        }
-      }
-      inSyncReplicasCount={64}
-      isFetched={true}
-      offlinePartitionCount={0}
-      onlinePartitionCount={64}
-      outOfSyncReplicasCount={0}
-      underReplicatedPartitionCount={0}
-      version="1"
-      zooKeeperStatus={1}
     >
-      <div
-        className="section"
+      <Brokers
+        activeControllers={1}
+        brokerCount={1}
+        diskUsage={
+          Array [
+            Object {
+              "brokerId": 1,
+              "segmentCount": 64,
+              "segmentSize": 60718,
+            },
+          ]
+        }
+        fetchBrokers={
+          [MockFunction] {
+            "calls": Array [
+              Array [
+                undefined,
+              ],
+            ],
+            "results": Array [
+              Object {
+                "type": "return",
+                "value": undefined,
+              },
+            ],
+          }
+        }
+        fetchClusterStats={
+          [MockFunction] {
+            "calls": Array [
+              Array [
+                undefined,
+              ],
+            ],
+            "results": Array [
+              Object {
+                "type": "return",
+                "value": undefined,
+              },
+            ],
+          }
+        }
+        inSyncReplicasCount={64}
+        isFetched={true}
+        offlinePartitionCount={0}
+        onlinePartitionCount={64}
+        outOfSyncReplicasCount={0}
+        underReplicatedPartitionCount={0}
+        version="1"
+        zooKeeperStatus={1}
       >
         <div
-          className="metrics-box mb-2"
+          className="section"
         >
-          <MetricsWrapper
-            title="Uptime"
-            wrapperClassName="is-flex-grow-1"
+          <div
+            className="metrics-box mb-2 is-flex"
           >
-            <div
-              className="is-flex-grow-1"
+            <Styled(MetricsWrapper)
+              title="Uptime"
             >
-              <h5
-                className="is-7 has-text-weight-medium mb-2"
-              >
-                Uptime
-              </h5>
-              <div
-                className="box"
+              <MetricsWrapper
+                className="sc-bdfBQB ewAWCQ"
+                title="Uptime"
               >
                 <div
-                  className="level"
+                  className="sc-bdfBQB ewAWCQ"
                 >
-                  <Indicator
-                    className="is-one-third"
-                    label="Total Brokers"
+                  <h5
+                    className="is-7 has-text-weight-medium mb-2"
                   >
-                    <div
-                      className="level-item is-one-third"
-                    >
-                      <div>
-                        <p
-                          className="is-size-8"
-                        >
-                          Total Brokers
-                        </p>
-                        <p
-                          className="is-size-6 has-text-weight-medium"
-                        >
-                          1
-                        </p>
-                      </div>
-                    </div>
-                  </Indicator>
-                  <Indicator
-                    className="is-one-third"
-                    label="Active Controllers"
+                    Uptime
+                  </h5>
+                  <div
+                    className="indicatorsWrapper"
                   >
-                    <div
-                      className="level-item is-one-third"
+                    <Styled(Indicator)
+                      label="Total Brokers"
                     >
-                      <div>
-                        <p
-                          className="is-size-8"
+                      <Indicator
+                        className="sc-gsTEea fGiIVV"
+                        label="Total Brokers"
+                      >
+                        <div
+                          className="sc-gsTEea fGiIVV"
                         >
-                          Active Controllers
-                        </p>
-                        <p
-                          className="is-size-6 has-text-weight-medium"
-                        >
-                          1
-                        </p>
-                      </div>
-                    </div>
-                  </Indicator>
-                  <Indicator
-                    className="is-one-third"
-                    label="Zookeeper Status"
-                  >
-                    <div
-                      className="level-item is-one-third"
+                          <div>
+                            <p
+                              className="is-size-8"
+                            >
+                              Total Brokers
+                            </p>
+                            1
+                          </div>
+                        </div>
+                      </Indicator>
+                    </Styled(Indicator)>
+                    <Styled(Indicator)
+                      label="Active Controllers"
                     >
-                      <div>
-                        <p
-                          className="is-size-8"
+                      <Indicator
+                        className="sc-gsTEea fGiIVV"
+                        label="Active Controllers"
+                      >
+                        <div
+                          className="sc-gsTEea fGiIVV"
                         >
-                          Zookeeper Status
-                        </p>
-                        <p
-                          className="is-size-6 has-text-weight-medium"
-                        >
-                          <span
-                            className="tag is-success"
-                          >
-                            Online
-                          </span>
-                        </p>
-                      </div>
-                    </div>
-                  </Indicator>
-                  <Indicator
-                    className="is-one-third"
-                    label="Version"
-                  >
-                    <div
-                      className="level-item is-one-third"
+                          <div>
+                            <p
+                              className="is-size-8"
+                            >
+                              Active Controllers
+                            </p>
+                            1
+                          </div>
+                        </div>
+                      </Indicator>
+                    </Styled(Indicator)>
+                    <Styled(Indicator)
+                      label="Zookeeper Status"
                     >
-                      <div>
-                        <p
-                          className="is-size-8"
+                      <Indicator
+                        className="sc-gsTEea fGiIVV"
+                        label="Zookeeper Status"
+                      >
+                        <div
+                          className="sc-gsTEea fGiIVV"
                         >
-                          Version
-                        </p>
-                        <p
-                          className="is-size-6 has-text-weight-medium"
+                          <div>
+                            <p
+                              className="is-size-8"
+                            >
+                              Zookeeper Status
+                            </p>
+                            <Styled(Tag)
+                              color="green"
+                              text="online"
+                            >
+                              <Tag
+                                className="sc-dlfnuX jmVcT"
+                                color="green"
+                                text="online"
+                              >
+                                <p
+                                  className="sc-dlfnuX jmVcT"
+                                >
+                                  online
+                                </p>
+                              </Tag>
+                            </Styled(Tag)>
+                          </div>
+                        </div>
+                      </Indicator>
+                    </Styled(Indicator)>
+                    <Styled(Indicator)
+                      label="Version"
+                    >
+                      <Indicator
+                        className="sc-gsTEea fGiIVV"
+                        label="Version"
+                      >
+                        <div
+                          className="sc-gsTEea fGiIVV"
                         >
-                          1
-                        </p>
-                      </div>
-                    </div>
-                  </Indicator>
+                          <div>
+                            <p
+                              className="is-size-8"
+                            >
+                              Version
+                            </p>
+                            1
+                          </div>
+                        </div>
+                      </Indicator>
+                    </Styled(Indicator)>
+                  </div>
                 </div>
-              </div>
-            </div>
-          </MetricsWrapper>
-          <MetricsWrapper
-            title="Partitions"
-            wrapperClassName="is-flex-grow-1"
-          >
-            <div
-              className="is-flex-grow-1"
+              </MetricsWrapper>
+            </Styled(MetricsWrapper)>
+            <Styled(MetricsWrapper)
+              title="Partitions"
             >
-              <h5
-                className="is-7 has-text-weight-medium mb-2"
-              >
-                Partitions
-              </h5>
-              <div
-                className="box"
+              <MetricsWrapper
+                className="sc-bdfBQB ewAWCQ"
+                title="Partitions"
               >
                 <div
-                  className="level"
+                  className="sc-bdfBQB ewAWCQ"
                 >
-                  <Indicator
-                    label="Online"
+                  <h5
+                    className="is-7 has-text-weight-medium mb-2"
                   >
-                    <div
-                      className="level-item"
-                    >
-                      <div>
-                        <p
-                          className="is-size-8"
-                        >
-                          Online
-                        </p>
-                        <p
-                          className="is-size-6 has-text-weight-medium"
-                        >
-                          <span
-                            className=""
-                          >
-                            64
-                          </span>
-                          <span
-                            className="has-text-weight-light"
-                          >
-                             
-                            of 
-                            64
-                          </span>
-                        </p>
-                      </div>
-                    </div>
-                  </Indicator>
-                  <Indicator
-                    label="URP"
-                    title="Under replicated partitions"
+                    Partitions
+                  </h5>
+                  <div
+                    className="indicatorsWrapper"
                   >
-                    <div
-                      className="level-item"
+                    <Styled(Indicator)
+                      label="Online"
                     >
-                      <div
+                      <Indicator
+                        className="sc-gsTEea fGiIVV"
+                        label="Online"
+                      >
+                        <div
+                          className="sc-gsTEea fGiIVV"
+                        >
+                          <div>
+                            <p
+                              className="is-size-8"
+                            >
+                              Online
+                            </p>
+                            <span
+                              className=""
+                            >
+                              64
+                            </span>
+                            <span
+                              className="has-text-weight-light"
+                            >
+                               
+                              of 
+                              64
+                            </span>
+                          </div>
+                        </div>
+                      </Indicator>
+                    </Styled(Indicator)>
+                    <Styled(Indicator)
+                      label="URP"
+                      title="Under replicated partitions"
+                    >
+                      <Indicator
+                        className="sc-gsTEea fGiIVV"
+                        label="URP"
                         title="Under replicated partitions"
                       >
-                        <p
-                          className="is-size-8"
+                        <div
+                          className="sc-gsTEea fGiIVV"
                         >
-                          URP
-                        </p>
-                        <p
-                          className="is-size-6 has-text-weight-medium"
-                        >
-                          0
-                        </p>
-                      </div>
-                    </div>
-                  </Indicator>
-                  <Indicator
-                    label="In Sync Replicas"
-                  >
-                    <div
-                      className="level-item"
-                    >
-                      <div>
-                        <p
-                          className="is-size-8"
-                        >
-                          In Sync Replicas
-                        </p>
-                        <p
-                          className="is-size-6 has-text-weight-medium"
-                        >
-                          64
-                        </p>
-                      </div>
-                    </div>
-                  </Indicator>
-                  <Indicator
-                    label="Out of Sync Replicas"
-                  >
-                    <div
-                      className="level-item"
-                    >
-                      <div>
-                        <p
-                          className="is-size-8"
-                        >
-                          Out of Sync Replicas
-                        </p>
-                        <p
-                          className="is-size-6 has-text-weight-medium"
-                        >
-                          0
-                        </p>
-                      </div>
-                    </div>
-                  </Indicator>
-                </div>
-              </div>
-            </div>
-          </MetricsWrapper>
-          <MetricsWrapper
-            multiline={true}
-            title="Disk Usage"
-            wrapperClassName="is-flex-grow-1"
-          >
-            <div
-              className="is-flex-grow-1"
-            >
-              <h5
-                className="is-7 has-text-weight-medium mb-2"
-              >
-                Disk Usage
-              </h5>
-              <div
-                className="box"
-              >
-                <div
-                  className="level level-multiline"
-                >
-                  <Indicator
-                    className="is-one-third"
-                    label="Broker"
-                  >
-                    <div
-                      className="level-item is-one-third"
-                    >
-                      <div>
-                        <p
-                          className="is-size-8"
-                        >
-                          Broker
-                        </p>
-                        <p
-                          className="is-size-6 has-text-weight-medium"
-                        >
-                          1
-                        </p>
-                      </div>
-                    </div>
-                  </Indicator>
-                  <Indicator
-                    className="is-one-third"
-                    label="Segment Size"
-                    title=""
-                  >
-                    <div
-                      className="level-item is-one-third"
-                    >
-                      <div
-                        title=""
-                      >
-                        <p
-                          className="is-size-8"
-                        >
-                          Segment Size
-                        </p>
-                        <p
-                          className="is-size-6 has-text-weight-medium"
-                        >
-                          <BytesFormatted
-                            value={60718}
+                          <div
+                            title="Under replicated partitions"
                           >
-                            <span>
-                              59KB
-                            </span>
-                          </BytesFormatted>
-                        </p>
-                      </div>
-                    </div>
-                  </Indicator>
-                  <Indicator
-                    className="is-one-third"
-                    label="Segment count"
-                  >
-                    <div
-                      className="level-item is-one-third"
+                            <p
+                              className="is-size-8"
+                            >
+                              URP
+                            </p>
+                            0
+                          </div>
+                        </div>
+                      </Indicator>
+                    </Styled(Indicator)>
+                    <Styled(Indicator)
+                      label="In Sync Replicas"
                     >
-                      <div>
-                        <p
-                          className="is-size-8"
+                      <Indicator
+                        className="sc-gsTEea fGiIVV"
+                        label="In Sync Replicas"
+                      >
+                        <div
+                          className="sc-gsTEea fGiIVV"
                         >
-                          Segment count
-                        </p>
-                        <p
-                          className="is-size-6 has-text-weight-medium"
+                          <div>
+                            <p
+                              className="is-size-8"
+                            >
+                              In Sync Replicas
+                            </p>
+                            64
+                          </div>
+                        </div>
+                      </Indicator>
+                    </Styled(Indicator)>
+                    <Styled(Indicator)
+                      label="Out of Sync Replicas"
+                    >
+                      <Indicator
+                        className="sc-gsTEea fGiIVV"
+                        label="Out of Sync Replicas"
+                      >
+                        <div
+                          className="sc-gsTEea fGiIVV"
                         >
-                          64
-                        </p>
-                      </div>
-                    </div>
-                  </Indicator>
+                          <div>
+                            <p
+                              className="is-size-8"
+                            >
+                              Out of Sync Replicas
+                            </p>
+                            0
+                          </div>
+                        </div>
+                      </Indicator>
+                    </Styled(Indicator)>
+                  </div>
                 </div>
-              </div>
-            </div>
-          </MetricsWrapper>
+              </MetricsWrapper>
+            </Styled(MetricsWrapper)>
+          </div>
         </div>
-      </div>
-    </Brokers>
+        <table
+          className="table is-fullwidth"
+        >
+          <thead>
+            <tr>
+              <th>
+                Broker
+              </th>
+              <th>
+                Segment size (Mb)
+              </th>
+              <th>
+                Segment Count
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              key="1"
+            >
+              <td>
+                1
+              </td>
+              <td>
+                <BytesFormatted
+                  value={60718}
+                >
+                  <span>
+                    59KB
+                  </span>
+                </BytesFormatted>
+              </td>
+              <td>
+                64
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </Brokers>
+    </Component>
   </Router>
 </StaticRouter>
 `;

--- a/kafka-ui-react-app/src/components/KsqlDb/List/List.tsx
+++ b/kafka-ui-react-app/src/components/KsqlDb/List/List.tsx
@@ -34,7 +34,7 @@ const List: FC = () => {
 
   return (
     <>
-      <MetricsWrapper wrapperClassName="is-justify-content-space-between">
+      <MetricsWrapper>
         <div className="column is-flex m-0 p-0">
           <Indicator
             className="level-left is-one-third mr-3"

--- a/kafka-ui-react-app/src/components/Topics/shared/Form/TopicForm.tsx
+++ b/kafka-ui-react-app/src/components/Topics/shared/Form/TopicForm.tsx
@@ -26,7 +26,6 @@ const TopicForm: React.FC<Props> = ({
   onSubmit,
 }) => {
   const {
-    register,
     formState: { errors },
   } = useFormContext();
 

--- a/kafka-ui-react-app/src/components/__tests__/__snapshots__/App.spec.tsx.snap
+++ b/kafka-ui-react-app/src/components/__tests__/__snapshots__/App.spec.tsx.snap
@@ -134,6 +134,14 @@ exports[`App view matches snapshot 1`] = `
                   "normal": "#171A1C",
                 },
               },
+              "tagStyles": Object {
+                "backgroundColor": Object {
+                  "gray": "#E3E6E8",
+                  "green": "#D6F5E0",
+                  "yellow": "#FFEECC",
+                },
+                "color": "#171A1C",
+              },
             }
           }
         >
@@ -344,15 +352,17 @@ exports[`App view matches snapshot 1`] = `
                             <div
                               className="metrics-box mb-2"
                             >
-                              <MetricsWrapper>
-                                <div>
+                              <Styled(MetricsWrapper)>
+                                <MetricsWrapper
+                                  className="sc-gsTEea kVeHiA"
+                                >
                                   <div
-                                    className="box"
+                                    className="sc-gsTEea kVeHiA"
                                   >
                                     <div
-                                      className="level"
+                                      className="indicatorsWrapper"
                                     >
-                                      <Indicator
+                                      <Styled(Indicator)
                                         className="is-justify-content-start"
                                         label={
                                           <span
@@ -362,22 +372,29 @@ exports[`App view matches snapshot 1`] = `
                                           </span>
                                         }
                                       >
-                                        <div
-                                          className="level-item is-justify-content-start"
+                                        <Indicator
+                                          className="sc-dlfnuX YlPZR is-justify-content-start"
+                                          label={
+                                            <span
+                                              className="tag is-success"
+                                            >
+                                              Online
+                                            </span>
+                                          }
                                         >
-                                          <div>
-                                            <p
-                                              className="is-size-8"
-                                            >
-                                              <span
-                                                className="tag is-success"
+                                          <div
+                                            className="sc-dlfnuX YlPZR is-justify-content-start"
+                                          >
+                                            <div>
+                                              <p
+                                                className="is-size-8"
                                               >
-                                                Online
-                                              </span>
-                                            </p>
-                                            <p
-                                              className="is-size-6 has-text-weight-medium"
-                                            >
+                                                <span
+                                                  className="tag is-success"
+                                                >
+                                                  Online
+                                                </span>
+                                              </p>
                                               <span
                                                 data-testid="onlineCount"
                                               >
@@ -389,11 +406,11 @@ exports[`App view matches snapshot 1`] = `
                                               >
                                                 cluster
                                               </span>
-                                            </p>
+                                            </div>
                                           </div>
-                                        </div>
-                                      </Indicator>
-                                      <Indicator
+                                        </Indicator>
+                                      </Styled(Indicator)>
+                                      <Styled(Indicator)
                                         className="is-justify-content-start"
                                         label={
                                           <span
@@ -403,22 +420,29 @@ exports[`App view matches snapshot 1`] = `
                                           </span>
                                         }
                                       >
-                                        <div
-                                          className="level-item is-justify-content-start"
+                                        <Indicator
+                                          className="sc-dlfnuX YlPZR is-justify-content-start"
+                                          label={
+                                            <span
+                                              className="tag is-light"
+                                            >
+                                              Offline
+                                            </span>
+                                          }
                                         >
-                                          <div>
-                                            <p
-                                              className="is-size-8"
-                                            >
-                                              <span
-                                                className="tag is-light"
+                                          <div
+                                            className="sc-dlfnuX YlPZR is-justify-content-start"
+                                          >
+                                            <div>
+                                              <p
+                                                className="is-size-8"
                                               >
-                                                Offline
-                                              </span>
-                                            </p>
-                                            <p
-                                              className="is-size-6 has-text-weight-medium"
-                                            >
+                                                <span
+                                                  className="tag is-light"
+                                                >
+                                                  Offline
+                                                </span>
+                                              </p>
                                               <span
                                                 data-testid="offlineCount"
                                               >
@@ -430,14 +454,14 @@ exports[`App view matches snapshot 1`] = `
                                               >
                                                 cluster
                                               </span>
-                                            </p>
+                                            </div>
                                           </div>
-                                        </div>
-                                      </Indicator>
+                                        </Indicator>
+                                      </Styled(Indicator)>
                                     </div>
                                   </div>
-                                </div>
-                              </MetricsWrapper>
+                                </MetricsWrapper>
+                              </Styled(MetricsWrapper)>
                             </div>
                             <div
                               className="p-4"

--- a/kafka-ui-react-app/src/components/common/Dashboard/Indicator.tsx
+++ b/kafka-ui-react-app/src/components/common/Dashboard/Indicator.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import cx from 'classnames';
+import { styled } from 'lib/themedStyles';
 
 interface Props {
   fetching?: boolean;
@@ -16,21 +16,34 @@ const Indicator: React.FC<Props> = ({
   children,
 }) => {
   return (
-    <div className={cx('level-item', className)}>
+    <div className={className}>
       <div title={title}>
         <p className="is-size-8">{label}</p>
-        <p className="is-size-6 has-text-weight-medium">
-          {fetching ? (
-            <span className="icon has-text-grey-light">
-              <i className="fas fa-spinner fa-pulse" />
-            </span>
-          ) : (
-            children
-          )}
-        </p>
+        {fetching ? (
+          <span className="icon has-text-grey-light">
+            <i className="fas fa-spinner fa-pulse" />
+          </span>
+        ) : (
+          children
+        )}
       </div>
     </div>
   );
 };
 
-export default Indicator;
+export default styled(Indicator)`
+  background-color: white;
+  height: 68px;
+  width: 100%;
+  max-width: 170px;
+  min-width: 120px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 12px 16px;
+  flex-grow: 1;
+
+  box-shadow: 3px 3px 3px rgba(0, 0, 0, 0.08);
+  margin: 0 0 3px 0;
+`;

--- a/kafka-ui-react-app/src/components/common/Dashboard/MetricsWrapper.tsx
+++ b/kafka-ui-react-app/src/components/common/Dashboard/MetricsWrapper.tsx
@@ -1,28 +1,34 @@
 import React from 'react';
-import cx from 'classnames';
+import { styled } from 'lib/themedStyles';
 
 interface Props {
   title?: string;
-  wrapperClassName?: string;
-  multiline?: boolean;
+  className?: string;
 }
 
-const MetricsWrapper: React.FC<Props> = ({
-  title,
-  children,
-  wrapperClassName,
-  multiline,
-}) => {
+const MetricsWrapper: React.FC<Props> = ({ title, children, className }) => {
   return (
-    <div className={wrapperClassName}>
+    <div className={className}>
       {title && <h5 className="is-7 has-text-weight-medium mb-2">{title}</h5>}
-      <div className="box">
-        <div className={cx('level', multiline ? 'level-multiline' : '')}>
-          {children}
-        </div>
-      </div>
+      <div className="indicatorsWrapper">{children}</div>
     </div>
   );
 };
 
-export default MetricsWrapper;
+export default styled(MetricsWrapper)`
+  width: 100%;
+  overflow-y: scroll;
+  .indicatorsWrapper {
+    display: flex;
+    gap: 2px;
+    > * {
+      &:first-child {
+        border-radius: 8px 0px 0px 8px;
+      }
+      &:last-child {
+        border-radius: 0px 8px 8px 0px;
+        margin-right: 3px;
+      }
+    }
+  }
+`;

--- a/kafka-ui-react-app/src/components/common/Dashboard/__tests__/MetricsWrapper.spec.tsx
+++ b/kafka-ui-react-app/src/components/common/Dashboard/__tests__/MetricsWrapper.spec.tsx
@@ -1,23 +1,14 @@
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import React from 'react';
 import MetricsWrapper from 'components/common/Dashboard/MetricsWrapper';
 
 describe('MetricsWrapper', () => {
-  it('correctly adds classes', () => {
-    const className = 'className';
-    const component = shallow(
-      <MetricsWrapper wrapperClassName={className} multiline />
-    );
-    expect(component.exists(`.${className}`)).toBeTruthy();
-    expect(component.exists('.level-multiline')).toBeTruthy();
-  });
-
   it('correctly renders children', () => {
-    let component = shallow(<MetricsWrapper />);
+    let component = mount(<MetricsWrapper />);
     expect(component.exists('.is-7')).toBeFalsy();
 
     const title = 'title';
-    component = shallow(<MetricsWrapper title={title} />);
+    component = mount(<MetricsWrapper title={title} />);
     expect(component.exists('.is-7')).toBeTruthy();
     expect(component.text()).toEqual(title);
   });

--- a/kafka-ui-react-app/src/components/common/Dashboard/__tests__/__snapshots__/Indicator.spec.tsx.snap
+++ b/kafka-ui-react-app/src/components/common/Dashboard/__tests__/__snapshots__/Indicator.spec.tsx.snap
@@ -1,27 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Indicator matches the snapshot 1`] = `
-<Indicator
+<Styled(Indicator)
   label="label"
   title="title"
 >
-  <div
-    className="level-item"
+  <Indicator
+    className="sc-bdfBQB eGAtcZ"
+    label="label"
+    title="title"
   >
     <div
-      title="title"
+      className="sc-bdfBQB eGAtcZ"
     >
-      <p
-        className="is-size-8"
+      <div
+        title="title"
       >
-        label
-      </p>
-      <p
-        className="is-size-6 has-text-weight-medium"
-      >
+        <p
+          className="is-size-8"
+        >
+          label
+        </p>
         Child
-      </p>
+      </div>
     </div>
-  </div>
-</Indicator>
+  </Indicator>
+</Styled(Indicator)>
 `;

--- a/kafka-ui-react-app/src/components/common/Tag/Tag.styled.tsx
+++ b/kafka-ui-react-app/src/components/common/Tag/Tag.styled.tsx
@@ -1,0 +1,27 @@
+import { styled } from 'lib/themedStyles';
+import React from 'react';
+
+interface Props {
+  className?: string;
+  text: string;
+  color: 'green' | 'gray' | 'yellow';
+}
+
+const Tag: React.FC<Props> = ({ text, className }) => {
+  return <p className={className}>{text}</p>;
+};
+
+export default styled(Tag)`
+  border: none;
+  border-radius: 16px;
+  height: 20px;
+  background-color: ${(props) =>
+    props.theme.tagStyles.backgroundColor[props.color]};
+  color: ${(props) => props.theme.tagStyles.color};
+  font-size: 12px;
+  display: inline-block;
+  padding-left: 0.75em;
+  padding-right: 0.75em;
+  padding-top: 1px;
+  text-align: center;
+`;

--- a/kafka-ui-react-app/src/lib/testHelpers.tsx
+++ b/kafka-ui-react-app/src/lib/testHelpers.tsx
@@ -47,7 +47,9 @@ export const containerRendersView = (
       await act(async () => {
         wrapper = mount(
           <Provider store={store}>
-            <StaticRouter>{container}</StaticRouter>
+            <StaticRouter>
+              <ThemeProvider theme={theme}>{container}</ThemeProvider>
+            </StaticRouter>
           </Provider>
         );
       });

--- a/kafka-ui-react-app/src/theme/theme.ts
+++ b/kafka-ui-react-app/src/theme/theme.ts
@@ -30,7 +30,7 @@ export const Colors = {
   red: {
     '50': '#E51A1A',
   },
-  orange: {
+  yellow: {
     '10': '#FFEECC',
   },
 };
@@ -113,6 +113,14 @@ const theme = {
       active: Colors.neutral[70],
       disabled: Colors.neutral[10],
     },
+  },
+  tagStyles: {
+    backgroundColor: {
+      green: Colors.green[10],
+      gray: Colors.neutral[10],
+      yellow: Colors.yellow[10],
+    },
+    color: Colors.neutral[90],
   },
 };
 


### PR DESCRIPTION
I have fully rewritten Metrics. The API almost didn't change: `MetricsWrapper` accepts title as a prop and `Indicator`s as children.`Indicator`s accept their content as children.
Rewritten Brokers page - moved third metrics block to the table, just like in design:
![image](https://user-images.githubusercontent.com/31561808/135085443-479b4343-ec4b-4558-a2d7-1571a95f3eb0.png)
In case of vertical overflow, I added scroll:
![image](https://user-images.githubusercontent.com/31561808/135085716-9a5ba35f-6dbc-460a-a7eb-896af18768b2.png)