### PR TITLE
Redesign menu

### DIFF
--- a/kafka-ui-react-app/src/components/App.scss
+++ b/kafka-ui-react-app/src/components/App.scss
@@ -1,4 +1,4 @@
-$navbar-width: 250px;
+$navbar-width: 201px;
 $navbar-height: 3.25rem;
 
 .Layout {
@@ -25,7 +25,7 @@ $navbar-height: 3.25rem;
     top: $navbar-height;
     left: 0;
     bottom: 0;
-    padding: 20px 20px;
+    padding: 8px 16px;
     overflow-y: scroll;
     transition: width 0.25s, opacity 0.25s, transform 0.25s,
       -webkit-transform 0.25s;

--- a/kafka-ui-react-app/src/components/Brokers/__test__/__snapshots__/Brokers.spec.tsx.snap
+++ b/kafka-ui-react-app/src/components/Brokers/__test__/__snapshots__/Brokers.spec.tsx.snap
@@ -71,18 +71,16 @@ exports[`Brokers Component Brokers Empty matches Brokers Empty snapshot 1`] = `
               },
             },
           },
-          "liStyles": Object {
-            "primary": Object {
-              "backgroundColor": Object {
-                "active": "#E3E6E8",
-                "hover": "#F1F2F3",
-                "normal": "#FFFFFF",
-              },
-              "color": Object {
-                "active": "#171A1C",
-                "hover": "#F1F2F3",
-                "normal": "#73848C",
-              },
+          "menuStyles": Object {
+            "backgroundColor": Object {
+              "active": "#E3E6E8",
+              "hover": "#F1F2F3",
+              "normal": "#FFFFFF",
+            },
+            "color": Object {
+              "active": "#171A1C",
+              "hover": "#73848C",
+              "normal": "#73848C",
             },
           },
           "secondaryTabStyles": Object {
@@ -520,18 +518,16 @@ exports[`Brokers Component Brokers matches snapshot 1`] = `
               },
             },
           },
-          "liStyles": Object {
-            "primary": Object {
-              "backgroundColor": Object {
-                "active": "#E3E6E8",
-                "hover": "#F1F2F3",
-                "normal": "#FFFFFF",
-              },
-              "color": Object {
-                "active": "#171A1C",
-                "hover": "#F1F2F3",
-                "normal": "#73848C",
-              },
+          "menuStyles": Object {
+            "backgroundColor": Object {
+              "active": "#E3E6E8",
+              "hover": "#F1F2F3",
+              "normal": "#FFFFFF",
+            },
+            "color": Object {
+              "active": "#171A1C",
+              "hover": "#73848C",
+              "normal": "#73848C",
             },
           },
           "secondaryTabStyles": Object {

--- a/kafka-ui-react-app/src/components/Nav/ClusterMenu.tsx
+++ b/kafka-ui-react-app/src/components/Nav/ClusterMenu.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Cluster, ClusterFeaturesEnum } from 'generated-sources';
-import { NavLink } from 'react-router-dom';
 import {
   clusterBrokersPath,
   clusterTopicsPath,
@@ -12,8 +11,8 @@ import {
 } from 'lib/paths';
 
 import ClusterMenuItem from './ClusterMenuItem/ClusterMenuItem';
-import DefaultClusterIcon from './DefaultClusterIcon';
-import ClusterStatusIcon from './ClusterStatusIcon';
+import ClusterTab from './ClusterMenuItem/ClusterTab/ClusterTab';
+import ClusterMenuList from './ClusterMenuList/ClusterMenuList.styled';
 
 interface Props {
   cluster: Cluster;
@@ -26,34 +25,32 @@ const ClusterMenu: React.FC<Props> = ({
     (key) => features?.includes(key),
     [features]
   );
+  const [isOpen, setisOpen] = React.useState(true);
   return (
-    <ul className="menu-list">
-      <li>
-        <NavLink
-          exact
-          to={clusterBrokersPath(name)}
-          title={name}
-          className="has-text-overflow-ellipsis"
-        >
-          {defaultCluster && <DefaultClusterIcon />}
-          {name}
-          <ClusterStatusIcon status={status} />
-        </NavLink>
+    <ClusterMenuList>
+      <hr />
+      <ClusterTab
+        exact
+        to={clusterBrokersPath(name)}
+        title={name}
+        status={status}
+        defaultCluster={defaultCluster}
+        isOpen={isOpen}
+        toggleClusterMenu={() => setisOpen((prev) => !prev)}
+      />
+      {isOpen && (
         <ul>
           <ClusterMenuItem
-            liType="primary"
             to={clusterBrokersPath(name)}
             activeClassName="is-active"
             title="Brokers"
           />
           <ClusterMenuItem
-            liType="primary"
             to={clusterTopicsPath(name)}
             activeClassName="is-active"
             title="Topics"
           />
           <ClusterMenuItem
-            liType="primary"
             to={clusterConsumerGroupsPath(name)}
             activeClassName="is-active"
             title="Consumers"
@@ -61,7 +58,6 @@ const ClusterMenu: React.FC<Props> = ({
 
           {hasFeatureConfigured(ClusterFeaturesEnum.SCHEMA_REGISTRY) && (
             <ClusterMenuItem
-              liType="primary"
               to={clusterSchemasPath(name)}
               activeClassName="is-active"
               title="Schema Registry"
@@ -69,7 +65,6 @@ const ClusterMenu: React.FC<Props> = ({
           )}
           {hasFeatureConfigured(ClusterFeaturesEnum.KAFKA_CONNECT) && (
             <ClusterMenuItem
-              liType="primary"
               to={clusterConnectorsPath(name)}
               activeClassName="is-active"
               title="Kafka Connect"
@@ -81,15 +76,14 @@ const ClusterMenu: React.FC<Props> = ({
           )}
           {hasFeatureConfigured(ClusterFeaturesEnum.KSQL_DB) && (
             <ClusterMenuItem
-              liType="primary"
               to={clusterKsqlDbPath(name)}
               activeClassName="is-active"
               title="KSQL DB"
             />
           )}
         </ul>
-      </li>
-    </ul>
+      )}
+    </ClusterMenuList>
   );
 };
 

--- a/kafka-ui-react-app/src/components/Nav/ClusterMenu.tsx
+++ b/kafka-ui-react-app/src/components/Nav/ClusterMenu.tsx
@@ -30,8 +30,6 @@ const ClusterMenu: React.FC<Props> = ({
     <ClusterMenuList>
       <hr />
       <ClusterTab
-        exact
-        to={clusterBrokersPath(name)}
         title={name}
         status={status}
         defaultCluster={defaultCluster}

--- a/kafka-ui-react-app/src/components/Nav/ClusterMenuItem/ClusterMenuItem.styled.ts
+++ b/kafka-ui-react-app/src/components/Nav/ClusterMenuItem/ClusterMenuItem.styled.ts
@@ -7,6 +7,7 @@ const StyledMenuItem = styled.li<MenuItemProps>`
   font-weight: ${(props) => (props.isTopLevel ? 500 : 'normal')};
   height: 32px;
   display: flex;
+  user-select: none;
   & a {
     width: 100%;
     padding: 0.5em 0.75em;

--- a/kafka-ui-react-app/src/components/Nav/ClusterMenuItem/ClusterMenuItem.tsx
+++ b/kafka-ui-react-app/src/components/Nav/ClusterMenuItem/ClusterMenuItem.tsx
@@ -3,29 +3,40 @@ import React from 'react';
 import { NavLink } from 'react-router-dom';
 
 export interface MenuItemProps {
-  liType: 'primary';
-  to?: string;
+  to: string;
   activeClassName?: string;
   title?: string;
   isInverted?: boolean;
+  exact?: boolean;
+  isTopLevel?: boolean;
   isActive?: (match: unknown, location: Location) => boolean;
 }
 
 const ClusterMenuItem: React.FC<MenuItemProps> = (props) => {
-  const { to, activeClassName, title, children, liType, isActive, ...rest } =
-    props;
+  const {
+    to,
+    activeClassName,
+    title,
+    children,
+    isActive,
+    exact,
+    isTopLevel,
+    ...rest
+  } = props;
 
   if (to) {
     return (
-      <StyledMenuItem to={to} liType={liType}>
+      <StyledMenuItem to={to} isTopLevel={isTopLevel}>
         <NavLink
           to={to}
           activeClassName={activeClassName}
           title={title}
+          exact={exact}
           {...rest}
         >
-          {children || title}
+          {title}
         </NavLink>
+        {children}
       </StyledMenuItem>
     );
   }

--- a/kafka-ui-react-app/src/components/Nav/ClusterMenuItem/ClusterTab/ClusterTab.styled.ts
+++ b/kafka-ui-react-app/src/components/Nav/ClusterMenuItem/ClusterTab/ClusterTab.styled.ts
@@ -1,18 +1,19 @@
 import { styled } from 'lib/themedStyles';
 
-import { MenuItemProps } from './ClusterMenuItem';
-
-const StyledMenuItem = styled.li<MenuItemProps>`
+const StyledClusterTab = styled.li`
   font-size: 14px;
-  font-weight: ${(props) => (props.isTopLevel ? 500 : 'normal')};
-  height: 32px;
-  display: flex;
-  & a {
-    width: 100%;
+  font-weight: 500;
+
+  & .cluster-tab-wrapper {
     padding: 0.5em 0.75em;
     cursor: pointer;
     text-decoration: none;
     margin: 0px 0px;
+    line-height: 20px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
     background-color: ${(props) =>
       props.theme.menuStyles.backgroundColor.normal};
     color: ${(props) => props.theme.menuStyles.color.normal};
@@ -22,14 +23,13 @@ const StyledMenuItem = styled.li<MenuItemProps>`
         props.theme.menuStyles.backgroundColor.hover};
       color: ${(props) => props.theme.menuStyles.color.hover};
     }
-    &.is-active {
-      background-color: ${(props) =>
-        props.theme.menuStyles.backgroundColor.active};
-      color: ${(props) => props.theme.menuStyles.color.active};
+
+    & .cluster-tab-l {
+      display: flex;
+      align-items: center;
+      gap: 10px;
     }
   }
 `;
 
-StyledMenuItem.displayName = 'StyledMenuItem';
-
-export default StyledMenuItem;
+export default StyledClusterTab;

--- a/kafka-ui-react-app/src/components/Nav/ClusterMenuItem/ClusterTab/ClusterTab.styled.ts
+++ b/kafka-ui-react-app/src/components/Nav/ClusterMenuItem/ClusterTab/ClusterTab.styled.ts
@@ -3,6 +3,7 @@ import { styled } from 'lib/themedStyles';
 const StyledClusterTab = styled.li`
   font-size: 14px;
   font-weight: 500;
+  user-select: none;
 
   & .cluster-tab-wrapper {
     padding: 0.5em 0.75em;

--- a/kafka-ui-react-app/src/components/Nav/ClusterMenuItem/ClusterTab/ClusterTab.tsx
+++ b/kafka-ui-react-app/src/components/Nav/ClusterMenuItem/ClusterTab/ClusterTab.tsx
@@ -7,11 +7,7 @@ import DefaultClusterIcon from 'components/Nav/DefaultClusterIcon';
 import ClusterTabChevron from './ClusterTabChevron';
 
 export interface ClusterTabProps {
-  to: string;
-  activeClassName?: string;
   title?: string;
-  exact?: boolean;
-  isActive?: (match: unknown, location: Location) => boolean;
   status: ServerStatus;
   defaultCluster?: boolean;
   isOpen: boolean;

--- a/kafka-ui-react-app/src/components/Nav/ClusterMenuItem/ClusterTab/ClusterTab.tsx
+++ b/kafka-ui-react-app/src/components/Nav/ClusterMenuItem/ClusterTab/ClusterTab.tsx
@@ -1,0 +1,42 @@
+import StyledClusterTab from 'components/Nav/ClusterMenuItem/ClusterTab/ClusterTab.styled';
+import { ServerStatus } from 'generated-sources';
+import React from 'react';
+import ClusterStatusIcon from 'components/Nav/ClusterStatusIcon';
+import DefaultClusterIcon from 'components/Nav/DefaultClusterIcon';
+
+import ClusterTabChevron from './ClusterTabChevron';
+
+export interface ClusterTabProps {
+  to: string;
+  activeClassName?: string;
+  title?: string;
+  exact?: boolean;
+  isActive?: (match: unknown, location: Location) => boolean;
+  status: ServerStatus;
+  defaultCluster?: boolean;
+  isOpen: boolean;
+  toggleClusterMenu: () => void;
+}
+
+const ClusterTab: React.FC<ClusterTabProps> = ({
+  status,
+  title,
+  defaultCluster,
+  isOpen,
+  toggleClusterMenu,
+}) => {
+  return (
+    <StyledClusterTab onClick={() => toggleClusterMenu()}>
+      <div className="cluster-tab-wrapper">
+        <div className="cluster-tab-l">
+          {defaultCluster && <DefaultClusterIcon />}
+          {title}
+          <ClusterStatusIcon status={status} />
+        </div>
+        <ClusterTabChevron isOpen={isOpen} />
+      </div>
+    </StyledClusterTab>
+  );
+};
+
+export default ClusterTab;

--- a/kafka-ui-react-app/src/components/Nav/ClusterMenuItem/ClusterTab/ClusterTabChevron.tsx
+++ b/kafka-ui-react-app/src/components/Nav/ClusterMenuItem/ClusterTab/ClusterTabChevron.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+interface Props {
+  isOpen: boolean;
+}
+
+const ClusterTabChevron: React.FC<Props> = ({ isOpen }) => {
+  return (
+    <svg
+      className="cluster-tab-chevron"
+      width="10"
+      height="6"
+      viewBox="0 0 10 6"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d={isOpen ? 'M8.99988 5L4.99988 1L0.999878 5' : 'M1 1L5 5L9 1'}
+        stroke="#73848C"
+      />
+    </svg>
+  );
+};
+
+export default ClusterTabChevron;

--- a/kafka-ui-react-app/src/components/Nav/ClusterMenuItem/ClusterTab/__tests__/ClusterTab.spec.tsx
+++ b/kafka-ui-react-app/src/components/Nav/ClusterMenuItem/ClusterTab/__tests__/ClusterTab.spec.tsx
@@ -11,7 +11,6 @@ describe('ClusterTab component', () => {
   const setupWrapper = (props?: Partial<ClusterTabProps>) => (
     <ThemeProvider theme={theme}>
       <ClusterTab
-        to="/test"
         status={ServerStatus.ONLINE}
         isOpen
         toggleClusterMenu={jest.fn()}
@@ -19,9 +18,18 @@ describe('ClusterTab component', () => {
       />
     </ThemeProvider>
   );
-  describe('with default props', () => {
+  describe('when online', () => {
     it('matches the snapshot', () => {
       const component = render(setupWrapper());
+      expect(component.baseElement).toMatchSnapshot();
+    });
+  });
+
+  describe('when offline', () => {
+    it('matches the snapshot', () => {
+      const component = render(
+        setupWrapper({ status: ServerStatus.OFFLINE, isOpen: false })
+      );
       expect(component.baseElement).toMatchSnapshot();
     });
   });

--- a/kafka-ui-react-app/src/components/Nav/ClusterMenuItem/ClusterTab/__tests__/ClusterTab.spec.tsx
+++ b/kafka-ui-react-app/src/components/Nav/ClusterMenuItem/ClusterTab/__tests__/ClusterTab.spec.tsx
@@ -1,0 +1,28 @@
+import { render } from '@testing-library/react';
+import ClusterTab, {
+  ClusterTabProps,
+} from 'components/Nav/ClusterMenuItem/ClusterTab/ClusterTab';
+import { ServerStatus } from 'generated-sources';
+import React from 'react';
+import { ThemeProvider } from 'styled-components';
+import theme from 'theme/theme';
+
+describe('ClusterTab component', () => {
+  const setupWrapper = (props?: Partial<ClusterTabProps>) => (
+    <ThemeProvider theme={theme}>
+      <ClusterTab
+        to="/test"
+        status={ServerStatus.ONLINE}
+        isOpen
+        toggleClusterMenu={jest.fn()}
+        {...props}
+      />
+    </ThemeProvider>
+  );
+  describe('with default props', () => {
+    it('matches the snapshot', () => {
+      const component = render(setupWrapper());
+      expect(component.baseElement).toMatchSnapshot();
+    });
+  });
+});

--- a/kafka-ui-react-app/src/components/Nav/ClusterMenuItem/ClusterTab/__tests__/__snapshots__/ClusterTab.spec.tsx.snap
+++ b/kafka-ui-react-app/src/components/Nav/ClusterMenuItem/ClusterTab/__tests__/__snapshots__/ClusterTab.spec.tsx.snap
@@ -1,0 +1,47 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ClusterTab component with default props matches the snapshot 1`] = `
+<body>
+  <div>
+    <li
+      class="sc-bdfBQB dqCete"
+    >
+      <div
+        class="cluster-tab-wrapper"
+      >
+        <div
+          class="cluster-tab-l"
+        >
+          <svg
+            fill="none"
+            height="4"
+            viewBox="0 0 4 4"
+            width="4"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <circle
+              cx="2"
+              cy="2"
+              fill="#5CD685"
+              r="2"
+            />
+          </svg>
+        </div>
+        <svg
+          class="cluster-tab-chevron"
+          fill="none"
+          height="6"
+          viewBox="0 0 10 6"
+          width="10"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M8.99988 5L4.99988 1L0.999878 5"
+            stroke="#73848C"
+          />
+        </svg>
+      </div>
+    </li>
+  </div>
+</body>
+`;

--- a/kafka-ui-react-app/src/components/Nav/ClusterMenuItem/ClusterTab/__tests__/__snapshots__/ClusterTab.spec.tsx.snap
+++ b/kafka-ui-react-app/src/components/Nav/ClusterMenuItem/ClusterTab/__tests__/__snapshots__/ClusterTab.spec.tsx.snap
@@ -1,10 +1,56 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ClusterTab component with default props matches the snapshot 1`] = `
+exports[`ClusterTab component when offline matches the snapshot 1`] = `
 <body>
   <div>
     <li
-      class="sc-bdfBQB dqCete"
+      class="sc-bdfBQB ibdTPX"
+    >
+      <div
+        class="cluster-tab-wrapper"
+      >
+        <div
+          class="cluster-tab-l"
+        >
+          <svg
+            fill="none"
+            height="4"
+            viewBox="0 0 4 4"
+            width="4"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <circle
+              cx="2"
+              cy="2"
+              fill="#E51A1A"
+              r="2"
+            />
+          </svg>
+        </div>
+        <svg
+          class="cluster-tab-chevron"
+          fill="none"
+          height="6"
+          viewBox="0 0 10 6"
+          width="10"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M1 1L5 5L9 1"
+            stroke="#73848C"
+          />
+        </svg>
+      </div>
+    </li>
+  </div>
+</body>
+`;
+
+exports[`ClusterTab component when online matches the snapshot 1`] = `
+<body>
+  <div>
+    <li
+      class="sc-bdfBQB ibdTPX"
     >
       <div
         class="cluster-tab-wrapper"

--- a/kafka-ui-react-app/src/components/Nav/ClusterMenuList/ClusterMenuList.styled.ts
+++ b/kafka-ui-react-app/src/components/Nav/ClusterMenuList/ClusterMenuList.styled.ts
@@ -1,0 +1,13 @@
+import { styled } from 'lib/themedStyles';
+
+const ClusterMenuList = styled.ul`
+  & hr {
+    margin: 0;
+    height: 1px;
+  }
+  & > ul {
+    padding-left: 8px;
+  }
+`;
+
+export default ClusterMenuList;

--- a/kafka-ui-react-app/src/components/Nav/ClusterStatusIcon.tsx
+++ b/kafka-ui-react-app/src/components/Nav/ClusterStatusIcon.tsx
@@ -1,27 +1,29 @@
 import { ServerStatus } from 'generated-sources';
-import React, { CSSProperties } from 'react';
+import React from 'react';
+import { Colors } from 'theme/theme';
 
 interface Props {
   status: ServerStatus;
 }
 
 const ClusterStatusIcon: React.FC<Props> = ({ status }) => {
-  const style: CSSProperties = {
-    width: '10px',
-    height: '10px',
-    borderRadius: '5px',
-    marginLeft: '7px',
-    padding: 0,
-  };
-
   return (
-    <span
-      className={`tag ${
-        status === ServerStatus.ONLINE ? 'is-success' : 'is-danger'
-      }`}
-      title={status}
-      style={style}
-    />
+    <svg
+      width="4"
+      height="4"
+      viewBox="0 0 4 4"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="2"
+        cy="2"
+        r="2"
+        fill={
+          status === ServerStatus.ONLINE ? Colors.green[40] : Colors.red[50]
+        }
+      />
+    </svg>
   );
 };
 

--- a/kafka-ui-react-app/src/components/Nav/DefaultClusterIcon.tsx
+++ b/kafka-ui-react-app/src/components/Nav/DefaultClusterIcon.tsx
@@ -1,11 +1,11 @@
 import React, { CSSProperties } from 'react';
+import { Colors } from 'theme/theme';
 
 const DefaultClusterIcon: React.FC = () => {
   const style: CSSProperties = {
     width: '.6rem',
-    left: '-8px',
-    top: '-4px',
     position: 'relative',
+    color: Colors.brand[20],
   };
 
   return (

--- a/kafka-ui-react-app/src/components/Nav/Nav.tsx
+++ b/kafka-ui-react-app/src/components/Nav/Nav.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import { NavLink } from 'react-router-dom';
 import cx from 'classnames';
 import { Cluster } from 'generated-sources';
+import { styled } from 'lib/themedStyles';
 
 import ClusterMenu from './ClusterMenu';
+import ClusterMenuItem from './ClusterMenuItem/ClusterMenuItem';
 
 interface Props {
   isClusterListFetched?: boolean;
@@ -16,16 +17,16 @@ const Nav: React.FC<Props> = ({
   clusters,
   className,
 }) => (
-  <aside className={cx('menu has-shadow has-background-white', className)}>
-    <p className="menu-label">General</p>
-    <ul className="menu-list">
-      <li>
-        <NavLink exact to="/ui" activeClassName="is-active" title="Dashboard">
-          Dashboard
-        </NavLink>
-      </li>
+  <aside className={cx('has-shadow has-background-white', className)}>
+    <ul>
+      <ClusterMenuItem
+        exact
+        to="/ui"
+        activeClassName="is-active"
+        title="Dashboard"
+        isTopLevel
+      />
     </ul>
-    <p className="menu-label">Clusters</p>
     {!isClusterListFetched && <div className="loader" />}
 
     {isClusterListFetched &&
@@ -35,4 +36,8 @@ const Nav: React.FC<Props> = ({
   </aside>
 );
 
-export default Nav;
+export default styled(Nav)`
+  > * {
+    padding-bottom: 4px;
+  }
+`;

--- a/kafka-ui-react-app/src/components/Nav/__tests__/ClusterMenu.spec.tsx
+++ b/kafka-ui-react-app/src/components/Nav/__tests__/ClusterMenu.spec.tsx
@@ -14,11 +14,11 @@ describe('ClusterMenu', () => {
 
   it('renders cluster menu without Kafka Connect & Schema Registry', () => {
     const wrapper = mountWithTheme(setupComponent(onlineClusterPayload));
-    expect(wrapper.find('ul.menu-list > li > NavLink').text()).toEqual(
+    expect(wrapper.find('ClusterTab').text()).toEqual(
       onlineClusterPayload.name
     );
 
-    expect(wrapper.find('ul.menu-list ul StyledMenuItem').length).toEqual(3);
+    expect(wrapper.find('ul ul StyledMenuItem').length).toEqual(3);
   });
 
   it('renders cluster menu with all enabled features', () => {
@@ -31,6 +31,6 @@ describe('ClusterMenu', () => {
         ],
       })
     );
-    expect(wrapper.find('ul.menu-list ul StyledMenuItem').length).toEqual(5);
+    expect(wrapper.find('ul ul StyledMenuItem').length).toEqual(5);
   });
 });

--- a/kafka-ui-react-app/src/components/Nav/__tests__/ClusterMenuItem.spec.tsx
+++ b/kafka-ui-react-app/src/components/Nav/__tests__/ClusterMenuItem.spec.tsx
@@ -6,28 +6,14 @@ import ClusterMenuItem, {
 import { mountWithTheme } from 'lib/testHelpers';
 
 describe('ClusterMenuItem', () => {
-  const setupComponent = (props: MenuItemProps) => (
+  const setupComponent = (props?: MenuItemProps) => (
     <StaticRouter>
-      <ClusterMenuItem {...props} />
+      <ClusterMenuItem to="/test" {...props} />
     </StaticRouter>
   );
 
-  it('renders with NavLink', () => {
-    const wrapper = mountWithTheme(
-      setupComponent({
-        liType: 'primary',
-        to: 'test-url',
-      })
-    );
-    expect(wrapper.find('a').length).toEqual(1);
-  });
-
-  it('renders without NavLink', () => {
-    const wrapper = mountWithTheme(
-      setupComponent({
-        liType: 'primary',
-      })
-    );
-    expect(wrapper.find('a').length).toEqual(0);
+  it('matches the snapshot', () => {
+    const wrapper = mountWithTheme(setupComponent());
+    expect(wrapper).toMatchSnapshot();
   });
 });

--- a/kafka-ui-react-app/src/components/Nav/__tests__/ClusterStatusIcon.spec.tsx
+++ b/kafka-ui-react-app/src/components/Nav/__tests__/ClusterStatusIcon.spec.tsx
@@ -4,19 +4,19 @@ import { ServerStatus } from 'generated-sources';
 import ClusterStatusIcon from 'components/Nav/ClusterStatusIcon';
 
 describe('ClusterStatusIcon', () => {
-  it('matches snapshot', () => {
-    const wrapper = mount(<ClusterStatusIcon status={ServerStatus.ONLINE} />);
-    expect(wrapper).toMatchSnapshot();
+  describe('when online', () => {
+    it('matches snapshot', () => {
+      const wrapper = mount(<ClusterStatusIcon status={ServerStatus.ONLINE} />);
+      expect(wrapper).toMatchSnapshot();
+    });
   });
 
-  it('renders online icon', () => {
-    const wrapper = mount(<ClusterStatusIcon status={ServerStatus.ONLINE} />);
-    expect(wrapper.exists('.is-success')).toBeTruthy();
-    expect(wrapper.exists('.is-danger')).toBeFalsy();
-  });
-  it('renders offline icon', () => {
-    const wrapper = mount(<ClusterStatusIcon status={ServerStatus.OFFLINE} />);
-    expect(wrapper.exists('.is-danger')).toBeTruthy();
-    expect(wrapper.exists('.is-success')).toBeFalsy();
+  describe('when offline', () => {
+    it('matches snapshot', () => {
+      const wrapper = mount(
+        <ClusterStatusIcon status={ServerStatus.OFFLINE} />
+      );
+      expect(wrapper).toMatchSnapshot();
+    });
   });
 });

--- a/kafka-ui-react-app/src/components/Nav/__tests__/Nav.spec.tsx
+++ b/kafka-ui-react-app/src/components/Nav/__tests__/Nav.spec.tsx
@@ -1,18 +1,25 @@
 import React from 'react';
-import { shallow } from 'enzyme';
 import { onlineClusterPayload } from 'redux/reducers/clusters/__test__/fixtures';
 import Nav from 'components/Nav/Nav';
+import { mountWithTheme } from 'lib/testHelpers';
+import { StaticRouter } from 'react-router';
 
 describe('Nav', () => {
   it('renders loader', () => {
-    const wrapper = shallow(<Nav clusters={[]} />);
+    const wrapper = mountWithTheme(
+      <StaticRouter>
+        <Nav clusters={[]} />
+      </StaticRouter>
+    );
     expect(wrapper.find('.loader')).toBeTruthy();
     expect(wrapper.exists('ClusterMenu')).toBeFalsy();
   });
 
   it('renders ClusterMenu', () => {
-    const wrapper = shallow(
-      <Nav clusters={[onlineClusterPayload]} isClusterListFetched />
+    const wrapper = mountWithTheme(
+      <StaticRouter>
+        <Nav clusters={[onlineClusterPayload]} isClusterListFetched />
+      </StaticRouter>
     );
     expect(wrapper.exists('.loader')).toBeFalsy();
     expect(wrapper.exists('ClusterMenu')).toBeTruthy();

--- a/kafka-ui-react-app/src/components/Nav/__tests__/__snapshots__/ClusterMenuItem.spec.tsx.snap
+++ b/kafka-ui-react-app/src/components/Nav/__tests__/__snapshots__/ClusterMenuItem.spec.tsx.snap
@@ -1,0 +1,69 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ClusterMenuItem matches the snapshot 1`] = `
+<StaticRouter>
+  <Router
+    history={
+      Object {
+        "action": "POP",
+        "block": [Function],
+        "createHref": [Function],
+        "go": [Function],
+        "goBack": [Function],
+        "goForward": [Function],
+        "listen": [Function],
+        "location": Object {
+          "hash": "",
+          "pathname": "/",
+          "search": "",
+          "state": undefined,
+        },
+        "push": [Function],
+        "replace": [Function],
+      }
+    }
+    staticContext={Object {}}
+  >
+    <ClusterMenuItem
+      to="/test"
+    >
+      <StyledMenuItem
+        to="/test"
+      >
+        <li
+          className="sc-bdfBQB lYvCt"
+          to="/test"
+        >
+          <NavLink
+            to="/test"
+          >
+            <Link
+              aria-current={null}
+              to={
+                Object {
+                  "hash": "",
+                  "pathname": "/test",
+                  "search": "",
+                  "state": null,
+                }
+              }
+            >
+              <LinkAnchor
+                aria-current={null}
+                href="/test"
+                navigate={[Function]}
+              >
+                <a
+                  aria-current={null}
+                  href="/test"
+                  onClick={[Function]}
+                />
+              </LinkAnchor>
+            </Link>
+          </NavLink>
+        </li>
+      </StyledMenuItem>
+    </ClusterMenuItem>
+  </Router>
+</StaticRouter>
+`;

--- a/kafka-ui-react-app/src/components/Nav/__tests__/__snapshots__/ClusterMenuItem.spec.tsx.snap
+++ b/kafka-ui-react-app/src/components/Nav/__tests__/__snapshots__/ClusterMenuItem.spec.tsx.snap
@@ -31,7 +31,7 @@ exports[`ClusterMenuItem matches the snapshot 1`] = `
         to="/test"
       >
         <li
-          className="sc-bdfBQB lYvCt"
+          className="sc-bdfBQB khcYE"
           to="/test"
         >
           <NavLink

--- a/kafka-ui-react-app/src/components/Nav/__tests__/__snapshots__/ClusterStatusIcon.spec.tsx.snap
+++ b/kafka-ui-react-app/src/components/Nav/__tests__/__snapshots__/ClusterStatusIcon.spec.tsx.snap
@@ -1,21 +1,43 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ClusterStatusIcon matches snapshot 1`] = `
+exports[`ClusterStatusIcon when offline matches snapshot 1`] = `
+<ClusterStatusIcon
+  status="offline"
+>
+  <svg
+    fill="none"
+    height="4"
+    viewBox="0 0 4 4"
+    width="4"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <circle
+      cx="2"
+      cy="2"
+      fill="#E51A1A"
+      r="2"
+    />
+  </svg>
+</ClusterStatusIcon>
+`;
+
+exports[`ClusterStatusIcon when online matches snapshot 1`] = `
 <ClusterStatusIcon
   status="online"
 >
-  <span
-    className="tag is-success"
-    style={
-      Object {
-        "borderRadius": "5px",
-        "height": "10px",
-        "marginLeft": "7px",
-        "padding": 0,
-        "width": "10px",
-      }
-    }
-    title="online"
-  />
+  <svg
+    fill="none"
+    height="4"
+    viewBox="0 0 4 4"
+    width="4"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <circle
+      cx="2"
+      cy="2"
+      fill="#5CD685"
+      r="2"
+    />
+  </svg>
 </ClusterStatusIcon>
 `;

--- a/kafka-ui-react-app/src/components/Nav/__tests__/__snapshots__/Nav.spec.tsx.snap
+++ b/kafka-ui-react-app/src/components/Nav/__tests__/__snapshots__/Nav.spec.tsx.snap
@@ -77,7 +77,7 @@ exports[`Nav renders ClusterMenu 1`] = `
                 to="/ui"
               >
                 <li
-                  className="sc-bdfBQB heggTX"
+                  className="sc-bdfBQB dLgsMO"
                   to="/ui"
                 >
                   <NavLink
@@ -142,18 +142,16 @@ exports[`Nav renders ClusterMenu 1`] = `
                 <hr />
                 <ClusterTab
                   defaultCluster={true}
-                  exact={true}
                   isOpen={true}
                   status="online"
                   title="secondLocal"
-                  to="/ui/clusters/secondLocal/brokers"
                   toggleClusterMenu={[Function]}
                 >
                   <styled.li
                     onClick={[Function]}
                   >
                     <li
-                      className="sc-gsTEea jFoTvC"
+                      className="sc-gsTEea gCBqHr"
                       onClick={[Function]}
                     >
                       <div
@@ -172,9 +170,8 @@ exports[`Nav renders ClusterMenu 1`] = `
                                 data-fa-transform="rotate-340"
                                 style={
                                   Object {
-                                    "left": "-8px",
+                                    "color": "#A3A3F5",
                                     "position": "relative",
-                                    "top": "-4px",
                                     "width": ".6rem",
                                   }
                                 }
@@ -232,7 +229,7 @@ exports[`Nav renders ClusterMenu 1`] = `
                       to="/ui/clusters/secondLocal/brokers"
                     >
                       <li
-                        className="sc-bdfBQB lYvCt"
+                        className="sc-bdfBQB khcYE"
                         to="/ui/clusters/secondLocal/brokers"
                       >
                         <NavLink
@@ -281,7 +278,7 @@ exports[`Nav renders ClusterMenu 1`] = `
                       to="/ui/clusters/secondLocal/topics"
                     >
                       <li
-                        className="sc-bdfBQB lYvCt"
+                        className="sc-bdfBQB khcYE"
                         to="/ui/clusters/secondLocal/topics"
                       >
                         <NavLink
@@ -330,7 +327,7 @@ exports[`Nav renders ClusterMenu 1`] = `
                       to="/ui/clusters/secondLocal/consumer-groups"
                     >
                       <li
-                        className="sc-bdfBQB lYvCt"
+                        className="sc-bdfBQB khcYE"
                         to="/ui/clusters/secondLocal/consumer-groups"
                       >
                         <NavLink

--- a/kafka-ui-react-app/src/components/Nav/__tests__/__snapshots__/Nav.spec.tsx.snap
+++ b/kafka-ui-react-app/src/components/Nav/__tests__/__snapshots__/Nav.spec.tsx.snap
@@ -1,48 +1,382 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Nav renders ClusterMenu 1`] = `
-<aside
-  className="menu has-shadow has-background-white"
->
-  <p
-    className="menu-label"
-  >
-    General
-  </p>
-  <ul
-    className="menu-list"
-  >
-    <li>
-      <NavLink
-        activeClassName="is-active"
-        exact={true}
-        title="Dashboard"
-        to="/ui"
-      >
-        Dashboard
-      </NavLink>
-    </li>
-  </ul>
-  <p
-    className="menu-label"
-  >
-    Clusters
-  </p>
-  <ClusterMenu
-    cluster={
+<StaticRouter>
+  <Router
+    history={
       Object {
-        "brokerCount": 1,
-        "bytesInPerSec": 1.55,
-        "bytesOutPerSec": 9.314,
-        "defaultCluster": true,
-        "features": Array [],
-        "name": "secondLocal",
-        "onlinePartitionCount": 6,
-        "status": "online",
-        "topicCount": 3,
+        "action": "POP",
+        "block": [Function],
+        "createHref": [Function],
+        "go": [Function],
+        "goBack": [Function],
+        "goForward": [Function],
+        "listen": [Function],
+        "location": Object {
+          "hash": "",
+          "pathname": "/",
+          "search": "",
+          "state": undefined,
+        },
+        "push": [Function],
+        "replace": [Function],
       }
     }
-    key="secondLocal"
-  />
-</aside>
+    staticContext={Object {}}
+  >
+    <Styled(Nav)
+      clusters={
+        Array [
+          Object {
+            "brokerCount": 1,
+            "bytesInPerSec": 1.55,
+            "bytesOutPerSec": 9.314,
+            "defaultCluster": true,
+            "features": Array [],
+            "name": "secondLocal",
+            "onlinePartitionCount": 6,
+            "status": "online",
+            "topicCount": 3,
+          },
+        ]
+      }
+      isClusterListFetched={true}
+    >
+      <Nav
+        className="sc-hKgJUU dAOeGn"
+        clusters={
+          Array [
+            Object {
+              "brokerCount": 1,
+              "bytesInPerSec": 1.55,
+              "bytesOutPerSec": 9.314,
+              "defaultCluster": true,
+              "features": Array [],
+              "name": "secondLocal",
+              "onlinePartitionCount": 6,
+              "status": "online",
+              "topicCount": 3,
+            },
+          ]
+        }
+        isClusterListFetched={true}
+      >
+        <aside
+          className="has-shadow has-background-white sc-hKgJUU dAOeGn"
+        >
+          <ul>
+            <ClusterMenuItem
+              activeClassName="is-active"
+              exact={true}
+              isTopLevel={true}
+              title="Dashboard"
+              to="/ui"
+            >
+              <StyledMenuItem
+                isTopLevel={true}
+                to="/ui"
+              >
+                <li
+                  className="sc-bdfBQB heggTX"
+                  to="/ui"
+                >
+                  <NavLink
+                    activeClassName="is-active"
+                    exact={true}
+                    title="Dashboard"
+                    to="/ui"
+                  >
+                    <Link
+                      aria-current={null}
+                      title="Dashboard"
+                      to={
+                        Object {
+                          "hash": "",
+                          "pathname": "/ui",
+                          "search": "",
+                          "state": null,
+                        }
+                      }
+                    >
+                      <LinkAnchor
+                        aria-current={null}
+                        href="/ui"
+                        navigate={[Function]}
+                        title="Dashboard"
+                      >
+                        <a
+                          aria-current={null}
+                          href="/ui"
+                          onClick={[Function]}
+                          title="Dashboard"
+                        >
+                          Dashboard
+                        </a>
+                      </LinkAnchor>
+                    </Link>
+                  </NavLink>
+                </li>
+              </StyledMenuItem>
+            </ClusterMenuItem>
+          </ul>
+          <ClusterMenu
+            cluster={
+              Object {
+                "brokerCount": 1,
+                "bytesInPerSec": 1.55,
+                "bytesOutPerSec": 9.314,
+                "defaultCluster": true,
+                "features": Array [],
+                "name": "secondLocal",
+                "onlinePartitionCount": 6,
+                "status": "online",
+                "topicCount": 3,
+              }
+            }
+            key="secondLocal"
+          >
+            <styled.ul>
+              <ul
+                className="sc-dlfnuX eaSOWX"
+              >
+                <hr />
+                <ClusterTab
+                  defaultCluster={true}
+                  exact={true}
+                  isOpen={true}
+                  status="online"
+                  title="secondLocal"
+                  to="/ui/clusters/secondLocal/brokers"
+                  toggleClusterMenu={[Function]}
+                >
+                  <styled.li
+                    onClick={[Function]}
+                  >
+                    <li
+                      className="sc-gsTEea jFoTvC"
+                      onClick={[Function]}
+                    >
+                      <div
+                        className="cluster-tab-wrapper"
+                      >
+                        <div
+                          className="cluster-tab-l"
+                        >
+                          <DefaultClusterIcon>
+                            <span
+                              className="icon has-text-primary is-small"
+                              title="Default Cluster"
+                            >
+                              <i
+                                className="fas fa-thumbtack"
+                                data-fa-transform="rotate-340"
+                                style={
+                                  Object {
+                                    "left": "-8px",
+                                    "position": "relative",
+                                    "top": "-4px",
+                                    "width": ".6rem",
+                                  }
+                                }
+                              />
+                            </span>
+                          </DefaultClusterIcon>
+                          secondLocal
+                          <ClusterStatusIcon
+                            status="online"
+                          >
+                            <svg
+                              fill="none"
+                              height="4"
+                              viewBox="0 0 4 4"
+                              width="4"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <circle
+                                cx="2"
+                                cy="2"
+                                fill="#5CD685"
+                                r="2"
+                              />
+                            </svg>
+                          </ClusterStatusIcon>
+                        </div>
+                        <ClusterTabChevron
+                          isOpen={true}
+                        >
+                          <svg
+                            className="cluster-tab-chevron"
+                            fill="none"
+                            height="6"
+                            viewBox="0 0 10 6"
+                            width="10"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M8.99988 5L4.99988 1L0.999878 5"
+                              stroke="#73848C"
+                            />
+                          </svg>
+                        </ClusterTabChevron>
+                      </div>
+                    </li>
+                  </styled.li>
+                </ClusterTab>
+                <ul>
+                  <ClusterMenuItem
+                    activeClassName="is-active"
+                    title="Brokers"
+                    to="/ui/clusters/secondLocal/brokers"
+                  >
+                    <StyledMenuItem
+                      to="/ui/clusters/secondLocal/brokers"
+                    >
+                      <li
+                        className="sc-bdfBQB lYvCt"
+                        to="/ui/clusters/secondLocal/brokers"
+                      >
+                        <NavLink
+                          activeClassName="is-active"
+                          title="Brokers"
+                          to="/ui/clusters/secondLocal/brokers"
+                        >
+                          <Link
+                            aria-current={null}
+                            title="Brokers"
+                            to={
+                              Object {
+                                "hash": "",
+                                "pathname": "/ui/clusters/secondLocal/brokers",
+                                "search": "",
+                                "state": null,
+                              }
+                            }
+                          >
+                            <LinkAnchor
+                              aria-current={null}
+                              href="/ui/clusters/secondLocal/brokers"
+                              navigate={[Function]}
+                              title="Brokers"
+                            >
+                              <a
+                                aria-current={null}
+                                href="/ui/clusters/secondLocal/brokers"
+                                onClick={[Function]}
+                                title="Brokers"
+                              >
+                                Brokers
+                              </a>
+                            </LinkAnchor>
+                          </Link>
+                        </NavLink>
+                      </li>
+                    </StyledMenuItem>
+                  </ClusterMenuItem>
+                  <ClusterMenuItem
+                    activeClassName="is-active"
+                    title="Topics"
+                    to="/ui/clusters/secondLocal/topics"
+                  >
+                    <StyledMenuItem
+                      to="/ui/clusters/secondLocal/topics"
+                    >
+                      <li
+                        className="sc-bdfBQB lYvCt"
+                        to="/ui/clusters/secondLocal/topics"
+                      >
+                        <NavLink
+                          activeClassName="is-active"
+                          title="Topics"
+                          to="/ui/clusters/secondLocal/topics"
+                        >
+                          <Link
+                            aria-current={null}
+                            title="Topics"
+                            to={
+                              Object {
+                                "hash": "",
+                                "pathname": "/ui/clusters/secondLocal/topics",
+                                "search": "",
+                                "state": null,
+                              }
+                            }
+                          >
+                            <LinkAnchor
+                              aria-current={null}
+                              href="/ui/clusters/secondLocal/topics"
+                              navigate={[Function]}
+                              title="Topics"
+                            >
+                              <a
+                                aria-current={null}
+                                href="/ui/clusters/secondLocal/topics"
+                                onClick={[Function]}
+                                title="Topics"
+                              >
+                                Topics
+                              </a>
+                            </LinkAnchor>
+                          </Link>
+                        </NavLink>
+                      </li>
+                    </StyledMenuItem>
+                  </ClusterMenuItem>
+                  <ClusterMenuItem
+                    activeClassName="is-active"
+                    title="Consumers"
+                    to="/ui/clusters/secondLocal/consumer-groups"
+                  >
+                    <StyledMenuItem
+                      to="/ui/clusters/secondLocal/consumer-groups"
+                    >
+                      <li
+                        className="sc-bdfBQB lYvCt"
+                        to="/ui/clusters/secondLocal/consumer-groups"
+                      >
+                        <NavLink
+                          activeClassName="is-active"
+                          title="Consumers"
+                          to="/ui/clusters/secondLocal/consumer-groups"
+                        >
+                          <Link
+                            aria-current={null}
+                            title="Consumers"
+                            to={
+                              Object {
+                                "hash": "",
+                                "pathname": "/ui/clusters/secondLocal/consumer-groups",
+                                "search": "",
+                                "state": null,
+                              }
+                            }
+                          >
+                            <LinkAnchor
+                              aria-current={null}
+                              href="/ui/clusters/secondLocal/consumer-groups"
+                              navigate={[Function]}
+                              title="Consumers"
+                            >
+                              <a
+                                aria-current={null}
+                                href="/ui/clusters/secondLocal/consumer-groups"
+                                onClick={[Function]}
+                                title="Consumers"
+                              >
+                                Consumers
+                              </a>
+                            </LinkAnchor>
+                          </Link>
+                        </NavLink>
+                      </li>
+                    </StyledMenuItem>
+                  </ClusterMenuItem>
+                </ul>
+              </ul>
+            </styled.ul>
+          </ClusterMenu>
+        </aside>
+      </Nav>
+    </Styled(Nav)>
+  </Router>
+</StaticRouter>
 `;

--- a/kafka-ui-react-app/src/components/Topics/List/__tests__/__snapshots__/List.spec.tsx.snap
+++ b/kafka-ui-react-app/src/components/Topics/List/__tests__/__snapshots__/List.spec.tsx.snap
@@ -65,18 +65,16 @@ exports[`List when it does not have readonly flag matches the snapshot 1`] = `
               },
             },
           },
-          "liStyles": Object {
-            "primary": Object {
-              "backgroundColor": Object {
-                "active": "#E3E6E8",
-                "hover": "#F1F2F3",
-                "normal": "#FFFFFF",
-              },
-              "color": Object {
-                "active": "#171A1C",
-                "hover": "#F1F2F3",
-                "normal": "#73848C",
-              },
+          "menuStyles": Object {
+            "backgroundColor": Object {
+              "active": "#E3E6E8",
+              "hover": "#F1F2F3",
+              "normal": "#FFFFFF",
+            },
+            "color": Object {
+              "active": "#171A1C",
+              "hover": "#73848C",
+              "normal": "#73848C",
             },
           },
           "secondaryTabStyles": Object {

--- a/kafka-ui-react-app/src/components/__tests__/__snapshots__/App.spec.tsx.snap
+++ b/kafka-ui-react-app/src/components/__tests__/__snapshots__/App.spec.tsx.snap
@@ -220,7 +220,7 @@ exports[`App view matches snapshot 1`] = `
                             to="/ui"
                           >
                             <li
-                              className="sc-bdfBQB heggTX"
+                              className="sc-bdfBQB dLgsMO"
                               to="/ui"
                             >
                               <NavLink

--- a/kafka-ui-react-app/src/components/__tests__/__snapshots__/App.spec.tsx.snap
+++ b/kafka-ui-react-app/src/components/__tests__/__snapshots__/App.spec.tsx.snap
@@ -94,18 +94,16 @@ exports[`App view matches snapshot 1`] = `
                   },
                 },
               },
-              "liStyles": Object {
-                "primary": Object {
-                  "backgroundColor": Object {
-                    "active": "#E3E6E8",
-                    "hover": "#F1F2F3",
-                    "normal": "#FFFFFF",
-                  },
-                  "color": Object {
-                    "active": "#171A1C",
-                    "hover": "#F1F2F3",
-                    "normal": "#73848C",
-                  },
+              "menuStyles": Object {
+                "backgroundColor": Object {
+                  "active": "#E3E6E8",
+                  "hover": "#F1F2F3",
+                  "normal": "#FFFFFF",
+                },
+                "color": Object {
+                  "active": "#171A1C",
+                  "hover": "#73848C",
+                  "normal": "#73848C",
                 },
               },
               "secondaryTabStyles": Object {
@@ -197,66 +195,76 @@ exports[`App view matches snapshot 1`] = `
               <div
                 className="Layout__sidebar has-shadow has-background-white"
               >
-                <Nav
+                <Styled(Nav)
                   clusters={Array []}
                   isClusterListFetched={true}
                 >
-                  <aside
-                    className="menu has-shadow has-background-white"
+                  <Nav
+                    className="sc-hKgJUU dAOeGn"
+                    clusters={Array []}
+                    isClusterListFetched={true}
                   >
-                    <p
-                      className="menu-label"
+                    <aside
+                      className="has-shadow has-background-white sc-hKgJUU dAOeGn"
                     >
-                      General
-                    </p>
-                    <ul
-                      className="menu-list"
-                    >
-                      <li>
-                        <NavLink
+                      <ul>
+                        <ClusterMenuItem
                           activeClassName="is-active"
                           exact={true}
+                          isTopLevel={true}
                           title="Dashboard"
                           to="/ui"
                         >
-                          <Link
-                            aria-current={null}
-                            title="Dashboard"
-                            to={
-                              Object {
-                                "hash": "",
-                                "pathname": "/ui",
-                                "search": "",
-                                "state": null,
-                              }
-                            }
+                          <StyledMenuItem
+                            isTopLevel={true}
+                            to="/ui"
                           >
-                            <LinkAnchor
-                              aria-current={null}
-                              href="/ui"
-                              navigate={[Function]}
-                              title="Dashboard"
+                            <li
+                              className="sc-bdfBQB heggTX"
+                              to="/ui"
                             >
-                              <a
-                                aria-current={null}
-                                href="/ui"
-                                onClick={[Function]}
+                              <NavLink
+                                activeClassName="is-active"
+                                exact={true}
                                 title="Dashboard"
+                                to="/ui"
                               >
-                                Dashboard
-                              </a>
-                            </LinkAnchor>
-                          </Link>
-                        </NavLink>
-                      </li>
-                    </ul>
-                    <p
-                      className="menu-label"
-                    >
-                      Clusters
-                    </p>
-                  </aside>
-                </Nav>
+                                <Link
+                                  aria-current={null}
+                                  title="Dashboard"
+                                  to={
+                                    Object {
+                                      "hash": "",
+                                      "pathname": "/ui",
+                                      "search": "",
+                                      "state": null,
+                                    }
+                                  }
+                                >
+                                  <LinkAnchor
+                                    aria-current={null}
+                                    href="/ui"
+                                    navigate={[Function]}
+                                    title="Dashboard"
+                                  >
+                                    <a
+                                      aria-current={null}
+                                      href="/ui"
+                                      onClick={[Function]}
+                                      title="Dashboard"
+                                    >
+                                      Dashboard
+                                    </a>
+                                  </LinkAnchor>
+                                </Link>
+                              </NavLink>
+                            </li>
+                          </StyledMenuItem>
+                        </ClusterMenuItem>
+                      </ul>
+                    </aside>
+                  </Nav>
+                </Styled(Nav)>
               </div>
               <div
                 aria-hidden="true"
@@ -365,10 +373,10 @@ exports[`App view matches snapshot 1`] = `
                             >
                               <Styled(MetricsWrapper)>
                                 <MetricsWrapper
-                                  className="sc-gsTEea kVeHiA"
+                                  className="sc-eCstlR gOlRWK"
                                 >
                                   <div
-                                    className="sc-gsTEea kVeHiA"
+                                    className="sc-eCstlR gOlRWK"
                                   >
                                     <div
                                       className="indicatorsWrapper"
@@ -384,7 +392,7 @@ exports[`App view matches snapshot 1`] = `
                                         }
                                       >
                                         <Indicator
-                                          className="sc-dlfnuX YlPZR is-justify-content-start"
+                                          className="sc-jSgvzq fboFlT is-justify-content-start"
                                           label={
                                             <span
                                               className="tag is-success"
@@ -394,7 +402,7 @@ exports[`App view matches snapshot 1`] = `
                                           }
                                         >
                                           <div
-                                            className="sc-dlfnuX YlPZR is-justify-content-start"
+                                            className="sc-jSgvzq fboFlT is-justify-content-start"
                                           >
                                             <div>
                                               <p
@@ -432,7 +440,7 @@ exports[`App view matches snapshot 1`] = `
                                         }
                                       >
                                         <Indicator
-                                          className="sc-dlfnuX YlPZR is-justify-content-start"
+                                          className="sc-jSgvzq fboFlT is-justify-content-start"
                                           label={
                                             <span
                                               className="tag is-light"
@@ -442,7 +450,7 @@ exports[`App view matches snapshot 1`] = `
                                           }
                                         >
                                           <div
-                                            className="sc-dlfnuX YlPZR is-justify-content-start"
+                                            className="sc-jSgvzq fboFlT is-justify-content-start"
                                           >
                                             <div>
                                               <p

--- a/kafka-ui-react-app/src/theme/theme.ts
+++ b/kafka-ui-react-app/src/theme/theme.ts
@@ -74,18 +74,16 @@ const theme = {
       L: '16px',
     },
   },
-  liStyles: {
-    primary: {
-      backgroundColor: {
-        normal: Colors.neutral[0],
-        hover: Colors.neutral[5],
-        active: Colors.neutral[10],
-      },
-      color: {
-        normal: Colors.neutral[50],
-        hover: Colors.neutral[5],
-        active: Colors.neutral[90],
-      },
+  menuStyles: {
+    backgroundColor: {
+      normal: Colors.neutral[0],
+      hover: Colors.neutral[5],
+      active: Colors.neutral[10],
+    },
+    color: {
+      normal: Colors.neutral[50],
+      hover: Colors.neutral[50],
+      active: Colors.neutral[90],
     },
   },
   thStyles: {


### PR DESCRIPTION
Finished styling the menu:
![image](https://user-images.githubusercontent.com/31561808/135810056-aa0769cb-1f97-40d3-9551-bcd7e7b44d44.png)

The cluster tab (the one with chevron and an online status indicator) is now not a `NavLink`, but rather a button that triggers the `ClusterMenu` to be unfolded:
![image](https://user-images.githubusercontent.com/31561808/135810518-ca2b28aa-26ec-4365-bce1-b10123fc09a6.png)

