### PR TITLE
#905: make schema definitions collapsible and set max lines for displaying schemas

### DIFF
--- a/kafka-ui-react-app/src/components/Schemas/Details/Details.tsx
+++ b/kafka-ui-react-app/src/components/Schemas/Details/Details.tsx
@@ -115,8 +115,9 @@ const Details: React.FC<DetailsProps> = ({
             <table className="table is-fullwidth">
               <thead>
                 <tr>
-                  <th>Version</th>
-                  <th>ID</th>
+                  <th style={{ width: 40 }}> </th>
+                  <th style={{ width: 90 }}>Version</th>
+                  <th style={{ width: 170 }}>ID</th>
                   <th>Schema</th>
                 </tr>
               </thead>

--- a/kafka-ui-react-app/src/components/Schemas/Details/LatestVersionItem.tsx
+++ b/kafka-ui-react-app/src/components/Schemas/Details/LatestVersionItem.tsx
@@ -36,7 +36,10 @@ const LatestVersionItem: React.FC<LatestVersionProps> = ({
           isFixedHeight
           name="schema"
           value={JSON.stringify(JSON.parse(schema), null, '\t')}
-          showGutter={false}
+          setOptions={{
+            showLineNumbers: false,
+            maxLines: 40,
+          }}
           readOnly
         />
       </div>

--- a/kafka-ui-react-app/src/components/Schemas/Details/SchemaVersion.tsx
+++ b/kafka-ui-react-app/src/components/Schemas/Details/SchemaVersion.tsx
@@ -9,18 +9,39 @@ interface SchemaVersionProps {
 const SchemaVersion: React.FC<SchemaVersionProps> = ({
   version: { version, id, schema },
 }) => {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const toggleIsOpen = () => setIsOpen(!isOpen);
   return (
     <tr>
+      <td>
+        <span
+          className="icon has-text-link is-size-7 is-small is-clickable"
+          onClick={toggleIsOpen}
+          aria-hidden
+        >
+          <i className={`fas fa-${isOpen ? 'minus' : 'plus'}`} />
+        </span>
+      </td>
       <td>{version}</td>
       <td>{id}</td>
-      <td>
-        <JSONEditor
-          isFixedHeight
-          name="schema"
-          value={JSON.stringify(JSON.parse(schema), null, '\t')}
-          showGutter={false}
-          readOnly
-        />
+      <td
+        className="has-text-overflow-ellipsis is-family-code"
+        style={{ width: '100%', maxWidth: 0 }}
+      >
+        {isOpen ? (
+          <JSONEditor
+            isFixedHeight
+            name="schema"
+            value={JSON.stringify(JSON.parse(schema), null, '\t')}
+            setOptions={{
+              showLineNumbers: false,
+              maxLines: 40,
+            }}
+            readOnly
+          />
+        ) : (
+          <span>{schema}</span>
+        )}
       </td>
     </tr>
   );

--- a/kafka-ui-react-app/src/components/Schemas/Details/__test__/SchemaVersion.spec.tsx
+++ b/kafka-ui-react-app/src/components/Schemas/Details/__test__/SchemaVersion.spec.tsx
@@ -8,7 +8,9 @@ describe('SchemaVersion', () => {
   it('renders versions', () => {
     const wrapper = shallow(<SchemaVersion version={versions[0]} />);
 
-    expect(wrapper.find('td').length).toEqual(3);
+    expect(wrapper.find('td').length).toEqual(4);
+    expect(wrapper.exists('JSONEditor')).toBeFalsy();
+    wrapper.find('.is-clickable').simulate('click');
     expect(wrapper.exists('JSONEditor')).toBeTruthy();
   });
 

--- a/kafka-ui-react-app/src/components/Schemas/Details/__test__/__snapshots__/Details.spec.tsx.snap
+++ b/kafka-ui-react-app/src/components/Schemas/Details/__test__/__snapshots__/Details.spec.tsx.snap
@@ -99,10 +99,31 @@ exports[`Details View Initial state matches snapshot 1`] = `
     >
       <thead>
         <tr>
-          <th>
+          <th
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+             
+          </th>
+          <th
+            style={
+              Object {
+                "width": 90,
+              }
+            }
+          >
             Version
           </th>
-          <th>
+          <th
+            style={
+              Object {
+                "width": 170,
+              }
+            }
+          >
             ID
           </th>
           <th>
@@ -247,10 +268,31 @@ exports[`Details View when page with schema versions loaded when schema has vers
     >
       <thead>
         <tr>
-          <th>
+          <th
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+             
+          </th>
+          <th
+            style={
+              Object {
+                "width": 90,
+              }
+            }
+          >
             Version
           </th>
-          <th>
+          <th
+            style={
+              Object {
+                "width": 170,
+              }
+            }
+          >
             ID
           </th>
           <th>
@@ -390,10 +432,31 @@ exports[`Details View when page with schema versions loaded when versions are em
     >
       <thead>
         <tr>
-          <th>
+          <th
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+             
+          </th>
+          <th
+            style={
+              Object {
+                "width": 90,
+              }
+            }
+          >
             Version
           </th>
-          <th>
+          <th
+            style={
+              Object {
+                "width": 170,
+              }
+            }
+          >
             ID
           </th>
           <th>

--- a/kafka-ui-react-app/src/components/Schemas/Details/__test__/__snapshots__/LatestVersionItem.spec.tsx.snap
+++ b/kafka-ui-react-app/src/components/Schemas/Details/__test__/__snapshots__/LatestVersionItem.spec.tsx.snap
@@ -52,7 +52,12 @@ exports[`LatestVersionItem matches snapshot 1`] = `
         isFixedHeight={true}
         name="schema"
         readOnly={true}
-        showGutter={false}
+        setOptions={
+          Object {
+            "maxLines": 40,
+            "showLineNumbers": false,
+          }
+        }
         value="{
 	\\"type\\": \\"record\\",
 	\\"name\\": \\"MyRecord1\\",

--- a/kafka-ui-react-app/src/components/Schemas/Details/__test__/__snapshots__/SchemaVersion.spec.tsx.snap
+++ b/kafka-ui-react-app/src/components/Schemas/Details/__test__/__snapshots__/SchemaVersion.spec.tsx.snap
@@ -3,29 +3,34 @@
 exports[`SchemaVersion matches snapshot 1`] = `
 <tr>
   <td>
-    1
+    <span
+      aria-hidden={true}
+      className="icon has-text-link is-size-7 is-small is-clickable"
+      onClick={[Function]}
+    >
+      <i
+        className="fas fa-plus"
+      />
+    </span>
   </td>
   <td>
     1
   </td>
   <td>
-    <JSONEditor
-      isFixedHeight={true}
-      name="schema"
-      readOnly={true}
-      showGutter={false}
-      value="{
-	\\"type\\": \\"record\\",
-	\\"name\\": \\"MyRecord1\\",
-	\\"namespace\\": \\"com.mycompany\\",
-	\\"fields\\": [
-		{
-			\\"name\\": \\"id\\",
-			\\"type\\": \\"long\\"
-		}
-	]
-}"
-    />
+    1
+  </td>
+  <td
+    className="has-text-overflow-ellipsis is-family-code"
+    style={
+      Object {
+        "maxWidth": 0,
+        "width": "100%",
+      }
+    }
+  >
+    <span>
+      {"type":"record","name":"MyRecord1","namespace":"com.mycompany","fields":[{"name":"id","type":"long"}]}
+    </span>
   </td>
 </tr>
 `;


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [x] **Breaking change?** (if so, please describe the impact and migration path for existing applications:)
no
<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)
I changed the schema registry page to make schema definitions collapsible.

**Is there anything you'd like reviewers to focus on?**
Maybe check the screenshots

**How Has This Been Tested?** (put an "X" next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually(please, describe, when necessary)
- [x] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

Main page
![image](https://user-images.githubusercontent.com/16617799/136966218-d7abc4fe-c495-4e39-89ca-565a6ed40b3e.png)
After click the "+"
![image](https://user-images.githubusercontent.com/16617799/136966229-20ad5372-0ee1-4d79-afe7-dda7b58f671a.png)
![image](https://user-images.githubusercontent.com/16617799/136966237-45648628-613c-426c-b188-a053f1425fbe.png)


**Checklist** (put an "X" next to an item, otherwise PR will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**) (no need)
- [x] My changes generate no new warnings(e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/provectus/kafka-ui/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/provectus/kafka-ui/blob/master/CODE-OF-CONDUCT.md)

Fixes #905 