### PR TITLE
Multiple topics deletion fix

### DIFF
--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/service/ClustersStorage.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/service/ClustersStorage.java
@@ -50,7 +50,8 @@ public class ClustersStorage {
     return kafkaCluster;
   }
 
-  public void onTopicDeleted(KafkaCluster cluster, String topicToDelete) {
+  public void onTopicDeleted(String clusterName, String topicToDelete) {
+    var cluster = kafkaClusters.get(clusterName);
     var topics = Optional.ofNullable(cluster.getTopics())
         .map(HashMap::new)
         .orElseGet(HashMap::new);
@@ -59,7 +60,8 @@ public class ClustersStorage {
     setKafkaCluster(cluster.getName(), updatedCluster);
   }
 
-  public void onTopicUpdated(KafkaCluster cluster, InternalTopic updatedTopic) {
+  public void onTopicUpdated(String clusterName, InternalTopic updatedTopic) {
+    var cluster = kafkaClusters.get(clusterName);
     var topics = Optional.ofNullable(cluster.getTopics())
         .map(HashMap::new)
         .orElseGet(HashMap::new);


### PR DESCRIPTION
When deleting multiple topics, several api calls executed. This change guarantees that clusterStorage will apply onTopicXXX action on latest cluster object version.

<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing applications:)
<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)

**Is there anything you'd like reviewers to focus on?**


**How Has This Been Tested?** (put an "X" next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually(please, describe, when necessary)
- [x] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "X" next to an item, otherwise PR will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings(e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/provectus/kafka-ui/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/provectus/kafka-ui/blob/master/CODE-OF-CONDUCT.md)