### PR TITLE
The highest logging level is "trace", not "all"

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,8 +177,8 @@ For example, if you want to use an environment variable to set the `name` parame
 |`KAFKA_CLUSTERS_0_DISABLELOGDIRSCOLLECTION`        	|Disable collecting segments information. It should be true for confluent cloud. Default: false
 |`KAFKA_CLUSTERS_0_KAFKACONNECT_0_NAME` |Given name for the Kafka Connect cluster
 |`KAFKA_CLUSTERS_0_KAFKACONNECT_0_ADDRESS` |Address of the Kafka Connect service endpoint 
-|`LOGGING_LEVEL_ROOT`        	| Setting log level (all, debug, info, warn, error, fatal, off). Default: debug
-|`LOGGING_LEVEL_COM_PROVECTUS`        	|Setting log level (all, debug, info, warn, error, fatal, off). Default: debug
+|`LOGGING_LEVEL_ROOT`        	| Setting log level (trace, debug, info, warn, error, fatal, off). Default: debug
+|`LOGGING_LEVEL_COM_PROVECTUS`        	|Setting log level (trace, debug, info, warn, error, fatal, off). Default: debug
 |`SERVER_PORT` |Port for the embedded server. Default `8080`
 |`KAFKA_CLUSTERS_0_JMXSSL` |Enable SSL for JMX? `true` or `false`. For advanced setup, see `kafka-ui-jmx-secured.yml`
 |`KAFKA_CLUSTERS_0_JMXUSERNAME` |Username for JMX authentication

--- a/README.md
+++ b/README.md
@@ -177,8 +177,8 @@ For example, if you want to use an environment variable to set the `name` parame
 |`KAFKA_CLUSTERS_0_DISABLELOGDIRSCOLLECTION`        	|Disable collecting segments information. It should be true for confluent cloud. Default: false
 |`KAFKA_CLUSTERS_0_KAFKACONNECT_0_NAME` |Given name for the Kafka Connect cluster
 |`KAFKA_CLUSTERS_0_KAFKACONNECT_0_ADDRESS` |Address of the Kafka Connect service endpoint 
-|`LOGGING_LEVEL_ROOT`        	| Setting log level (all, debug, info, warn, error, fatal, off, trace). Default: debug
-|`LOGGING_LEVEL_COM_PROVECTUS`        	|Setting log level (all, debug, info, warn, error, fatal, off, trace). Default: debug
+|`LOGGING_LEVEL_ROOT`        	| Setting log level (trace, debug, info, warn, error, fatal, off). Default: debug
+|`LOGGING_LEVEL_COM_PROVECTUS`        	|Setting log level (trace, debug, info, warn, error, fatal, off). Default: debug
 |`SERVER_PORT` |Port for the embedded server. Default `8080`
 |`KAFKA_CLUSTERS_0_JMXSSL` |Enable SSL for JMX? `true` or `false`. For advanced setup, see `kafka-ui-jmx-secured.yml`
 |`KAFKA_CLUSTERS_0_JMXUSERNAME` |Username for JMX authentication

--- a/README.md
+++ b/README.md
@@ -177,8 +177,8 @@ For example, if you want to use an environment variable to set the `name` parame
 |`KAFKA_CLUSTERS_0_DISABLELOGDIRSCOLLECTION`        	|Disable collecting segments information. It should be true for confluent cloud. Default: false
 |`KAFKA_CLUSTERS_0_KAFKACONNECT_0_NAME` |Given name for the Kafka Connect cluster
 |`KAFKA_CLUSTERS_0_KAFKACONNECT_0_ADDRESS` |Address of the Kafka Connect service endpoint 
-|`LOGGING_LEVEL_ROOT`        	| Setting log level (trace, debug, info, warn, error, fatal, off). Default: debug
-|`LOGGING_LEVEL_COM_PROVECTUS`        	|Setting log level (trace, debug, info, warn, error, fatal, off). Default: debug
+|`LOGGING_LEVEL_ROOT`        	| Setting log level (all, debug, info, warn, error, fatal, off, trace). Default: debug
+|`LOGGING_LEVEL_COM_PROVECTUS`        	|Setting log level (all, debug, info, warn, error, fatal, off, trace). Default: debug
 |`SERVER_PORT` |Port for the embedded server. Default `8080`
 |`KAFKA_CLUSTERS_0_JMXSSL` |Enable SSL for JMX? `true` or `false`. For advanced setup, see `kafka-ui-jmx-secured.yml`
 |`KAFKA_CLUSTERS_0_JMXUSERNAME` |Username for JMX authentication


### PR DESCRIPTION
The value "all" for LOGGING_LEVEL_ROOT is logged as invalid at startup:
java.lang.IllegalArgumentException: No enum constant org.springframework.boot.logging.LogLevel.all

<!-- ignore-task-list-start -->
- [ ] **Breaking change?**
<!-- ignore-task-list-end -->
**What changes did you make?**

README update to fix the highest logging value.
The value "all" for LOGGING_LEVEL_ROOT is logged as invalid at startup:
java.lang.IllegalArgumentException: No enum constant org.springframework.boot.logging.LogLevel.all
The value "trace" is valid and increase the verbosity as compared to debug.

**Is there anything you'd like reviewers to focus on?**


**How Has This Been Tested?** (put an "X" next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (by deploying a pod kafka-ui in a kubernetes environment)
- [ ] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "X" next to an item, otherwise PR will fail)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [ ] My changes generate no new warnings(e.g. Sonar is happy)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

Check out [Contributing](https://github.com/provectus/kafka-ui/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/provectus/kafka-ui/blob/master/CODE-OF-CONDUCT.md)