### PR TITLE
Added Connector examples (GitHub Source, S3 Sink)

### DIFF
--- a/docker/connectors/github-source.json
+++ b/docker/connectors/github-source.json
@@ -1,0 +1,20 @@
+{
+  "name": "github-source",
+  "config":
+  {
+    "connector.class": "io.confluent.connect.github.GithubSourceConnector",
+    "confluent.topic.bootstrap.servers": "kafka0:29092, kafka1:29092",
+    "confluent.topic.replication.factor": "1",
+    "tasks.max": "1",
+    "github.service.url": "https://api.github.com",
+    "github.access.token": "",
+    "github.repositories": "provectus/kafka-ui",
+    "github.resources": "issues,commits,pull_requests",
+    "github.since": "2019-01-01",
+    "topic.name.pattern": "github-${resourceName}",
+    "key.converter": "org.apache.kafka.connect.json.JsonConverter",
+    "key.converter.schema.registry.url": "http://schemaregistry0:8085",
+    "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+    "value.converter.schema.registry.url": "http://schemaregistry0:8085"
+  }
+}

--- a/docker/connectors/s3-sink.json
+++ b/docker/connectors/s3-sink.json
@@ -1,0 +1,18 @@
+{
+  "name": "s3-sink",
+  "config":
+  {
+    "connector.class": "io.confluent.connect.s3.S3SinkConnector",
+    "topics": "github-issues, github-pull_requests, github-commits",
+    "tasks.max": "1",
+    "s3.region": "eu-central-1",
+    "s3.bucket.name": "kafka-ui-s3-sink-connector",
+    "s3.part.size": "5242880",
+    "flush.size": "3",
+    "storage.class": "io.confluent.connect.s3.storage.S3Storage",
+    "format.class": "io.confluent.connect.s3.format.json.JsonFormat",
+    "schema.generator.class": "io.confluent.connect.storage.hive.schema.DefaultSchemaGenerator",
+    "partitioner.class": "io.confluent.connect.storage.partitioner.DefaultPartitioner",
+    "schema.compatibility": "BACKWARD"
+  }
+}

--- a/docker/kafka-connect/Dockerfile
+++ b/docker/kafka-connect/Dockerfile
@@ -2,4 +2,7 @@ ARG image
 FROM ${image}
 
 ## Install connectors
-RUN echo "\nInstalling JDBC connector...\n" && confluent-hub install --no-prompt confluentinc/kafka-connect-jdbc:latest
+RUN echo "\nInstalling all required connectors...\n" && \
+confluent-hub install --no-prompt confluentinc/kafka-connect-jdbc:latest && \
+confluent-hub install --no-prompt confluentinc/kafka-connect-github:latest && \
+confluent-hub install --no-prompt confluentinc/kafka-connect-s3:latest

--- a/docker/kafka-ui-connectors.yaml
+++ b/docker/kafka-ui-connectors.yaml
@@ -140,6 +140,8 @@ services:
       CONNECT_INTERNAL_VALUE_CONVERTER: org.apache.kafka.connect.json.JsonConverter
       CONNECT_REST_ADVERTISED_HOST_NAME: kafka-connect0
       CONNECT_PLUGIN_PATH: "/usr/share/java,/usr/share/confluent-hub-components"
+#      AWS_ACCESS_KEY_ID: ""
+#      AWS_SECRET_ACCESS_KEY: ""
 
   kafka-init-topics:
     image: confluentinc/cp-kafka:5.2.4

--- a/docker/kafka-ui.yaml
+++ b/docker/kafka-ui.yaml
@@ -115,7 +115,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_TOPIC: _schemas
 
   kafka-connect0:
-    image: confluentinc/cp-kafka-connect:5.2.4
+    image: confluentinc/cp-kafka-connect:6.0.1
     ports:
       - 8083:8083
     depends_on:


### PR DESCRIPTION
1. Now when running kafka-ui-connectors.yaml connectors for S3 and GitHub are automatically installed within the kafka-connect container.

2. Connectors json config file templates added to docker/connectors directory.