### PR TITLE
[kafka-ui chart] Add extra podLabels and ingress/egress custom rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,5 @@ build/
 
 *.tar.gz
 *.tgz
-**/charts/
 
 /docker/*.override.yaml

--- a/charts/kafka-ui/Chart.yaml
+++ b/charts/kafka-ui/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: kafka-ui
 description: A Helm chart for kafka-UI
 type: application
-version: 0.0.1
+version: 0.0.2
 appVersion: latest
 icon: https://github.com/provectus/kafka-ui/raw/master/images/kafka-ui-logo.png

--- a/charts/kafka-ui/README.md
+++ b/charts/kafka-ui/README.md
@@ -12,6 +12,9 @@ Most of the Helm charts parameters are common, follow table describe unique para
 | `existingSecret`| Name of the existing Secret with Kafka-UI environment variables| `nil`|
 | `envs.secret`| Set of the sensitive environment variables to pass to Kafka-UI | `{}`|
 | `envs.config`| Set of the environment variables to pass to Kafka-UI | `{}`|
+| `networkPolicy.enabled` | Enable network policies | `false`|
+| `networkPolicy.egressRules.customRules` | Custom network egress policy rules | `{}`|
+| `networkPolicy.ingressRules.customRules` | Custom network ingress policy rules | `{}`|
 | `podLabels` | Extra labels for Kafka-UI pod | `{}`|
 
 ## Example

--- a/charts/kafka-ui/README.md
+++ b/charts/kafka-ui/README.md
@@ -13,8 +13,8 @@ Most of the Helm charts parameters are common, follow table describe unique para
 | `envs.secret`| Set of the sensitive environment variables to pass to Kafka-UI | `{}`|
 | `envs.config`| Set of the environment variables to pass to Kafka-UI | `{}`|
 | `networkPolicy.enabled` | Enable network policies | `false`|
-| `networkPolicy.egressRules.customRules` | Custom network egress policy rules | `{}`|
-| `networkPolicy.ingressRules.customRules` | Custom network ingress policy rules | `{}`|
+| `networkPolicy.egressRules.customRules` | Custom network egress policy rules | `[]`|
+| `networkPolicy.ingressRules.customRules` | Custom network ingress policy rules | `[]`|
 | `podLabels` | Extra labels for Kafka-UI pod | `{}`|
 
 ## Example

--- a/charts/kafka-ui/README.md
+++ b/charts/kafka-ui/README.md
@@ -1,20 +1,26 @@
 # Kafka-UI Helm Chart
+
 ## Configuration
+
 Most of the Helm charts parameters are common, follow table describe unique parameters related to application configuration.
+
 ### Kafka-UI parameters
+
 | Parameter| Description| Default|
 |---|---|---|
 | `existingConfigMap`| Name of the existing ConfigMap with Kafka-UI environment variables | `nil`|
 | `existingSecret`| Name of the existing Secret with Kafka-UI environment variables| `nil`|
 | `envs.secret`| Set of the sensitive environment variables to pass to Kafka-UI | `{}`|
 | `envs.config`| Set of the environment variables to pass to Kafka-UI | `{}`|
+| `podLabels` | Extra labels for Kafka-UI pod | `{}`|
 
 ## Example
+
 To install Kafka-UI need to execute follow:
 ``` bash
 helm repo add kafka-ui https://provectus.github.io/kafka-ui
 helm install kafka-ui kafka-ui/kafka-ui --set envs.config.KAFKA_CLUSTERS_0_NAME=local --set envs.config.KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS=kafka:9092
-``` 
+```
 To connect to Kafka-UI web application need to execute:
 ``` bash
 kubectl port-forward svc/kafka-ui 8080:80

--- a/charts/kafka-ui/templates/deployment.yaml
+++ b/charts/kafka-ui/templates/deployment.yaml
@@ -21,6 +21,9 @@ spec:
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
       labels:
         {{- include "kafka-ui.selectorLabels" . | nindent 8 }}
+        {{- if .Values.podLabels }}
+        {{- toYaml .Values.podLabels | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/kafka-ui/templates/networkpolicy-egress.yaml
+++ b/charts/kafka-ui/templates/networkpolicy-egress.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.networkPolicy.enabled .Values.networkPolicy.egressRules.customRules }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ printf "%s-egress" (include "kafka-ui.fullname" .) }}
+  labels:
+    {{- include "kafka-ui.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "kafka-ui.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Egress
+  egress:
+    {{- if .Values.networkPolicy.egressRules.customRules }}
+    {{- toYaml .Values.networkPolicy.egressRules.customRules | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/kafka-ui/templates/networkpolicy-ingress.yaml
+++ b/charts/kafka-ui/templates/networkpolicy-ingress.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.networkPolicy.enabled .Values.networkPolicy.ingressRules.customRules }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ printf "%s-ingress" (include "kafka-ui.fullname" .) }}
+  labels:
+    {{- include "kafka-ui.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "kafka-ui.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    {{- if .Values.networkPolicy.ingressRules.customRules }}
+    {{- toYaml .Values.networkPolicy.ingressRules.customRules | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/kafka-ui/values.yaml
+++ b/charts/kafka-ui/values.yaml
@@ -35,7 +35,7 @@ networkPolicy:
     ##       - namespaceSelector:
     ##           matchLabels:
     ##             label: example
-    customRules: {}
+    customRules: []
   ingressRules:
     ## Additional custom ingress rules
     ## e.g:
@@ -44,7 +44,7 @@ networkPolicy:
     ##       - namespaceSelector:
     ##           matchLabels:
     ##             label: example
-    customRules: {}
+    customRules: []
 
 podAnnotations: {}
 podLabels: {}

--- a/charts/kafka-ui/values.yaml
+++ b/charts/kafka-ui/values.yaml
@@ -26,6 +26,7 @@ envs:
   config: {}
 
 podAnnotations: {}
+podLabels: {}
 
 podSecurityContext: {}
   # fsGroup: 2000

--- a/charts/kafka-ui/values.yaml
+++ b/charts/kafka-ui/values.yaml
@@ -25,6 +25,27 @@ envs:
   secret: {}
   config: {}
 
+networkPolicy:
+  enabled: false
+  egressRules:
+    ## Additional custom egress rules
+    ## e.g:
+    ## customRules:
+    ##   - to:
+    ##       - namespaceSelector:
+    ##           matchLabels:
+    ##             label: example
+    customRules: {}
+  ingressRules:
+    ## Additional custom ingress rules
+    ## e.g:
+    ## customRules:
+    ##   - from:
+    ##       - namespaceSelector:
+    ##           matchLabels:
+    ##             label: example
+    customRules: {}
+
 podAnnotations: {}
 podLabels: {}
 


### PR DESCRIPTION
Make it possible to declare extra labels and network egress/ingress rules for the Kafka-UI pod.

<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing applications:)
<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)

Make it possible to declare extra labels (`podLabels`), network egress/ingress rules for the Kafka-UI pod.

**Is there anything you'd like reviewers to focus on?**

I modified `.gitignore` to be able to make this PR but maybe this will have side effects to the application packaging?

**How Has This Been Tested?** (put an "X" next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (some pods have been deployed with this feature enabled)
- [ ] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "X" next to an item, otherwise PR will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings(e.g. Sonar is happy)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/provectus/kafka-ui/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/provectus/kafka-ui/blob/master/CODE-OF-CONDUCT.md)