### PR TITLE
Kafka API timeout fixes + doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,11 @@ For example, if you want to use an environment variable to set the `name` parame
 
 |Name               	|Description
 |-----------------------|-------------------------------
-|`SERVER_SERVLET_CONTEXT_PATH` | URI basePath
+|`SERVER_SERVLET_CONTEXT_PATH`  | URI basePath
+|`LOGGING_LEVEL_ROOT`        	| Setting log level (trace, debug, info, warn, error, fatal, off). Default: debug
+|`LOGGING_LEVEL_COM_PROVECTUS`  |Setting log level (trace, debug, info, warn, error, fatal, off). Default: debug
+|`SERVER_PORT` |Port for the embedded server. Default: `8080`
+|`KAFKA_ADMIN-CLIENT-TIMEOUT` | Kafka API timeout in ms. Default: `30000`
 |`KAFKA_CLUSTERS_0_NAME` | Cluster name
 |`KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS` 	|Address where to connect 
 |`KAFKA_CLUSTERS_0_ZOOKEEPER` 	| Zookeeper service address 
@@ -177,9 +181,6 @@ For example, if you want to use an environment variable to set the `name` parame
 |`KAFKA_CLUSTERS_0_DISABLELOGDIRSCOLLECTION`        	|Disable collecting segments information. It should be true for confluent cloud. Default: false
 |`KAFKA_CLUSTERS_0_KAFKACONNECT_0_NAME` |Given name for the Kafka Connect cluster
 |`KAFKA_CLUSTERS_0_KAFKACONNECT_0_ADDRESS` |Address of the Kafka Connect service endpoint 
-|`LOGGING_LEVEL_ROOT`        	| Setting log level (trace, debug, info, warn, error, fatal, off). Default: debug
-|`LOGGING_LEVEL_COM_PROVECTUS`        	|Setting log level (trace, debug, info, warn, error, fatal, off). Default: debug
-|`SERVER_PORT` |Port for the embedded server. Default `8080`
 |`KAFKA_CLUSTERS_0_JMXSSL` |Enable SSL for JMX? `true` or `false`. For advanced setup, see `kafka-ui-jmx-secured.yml`
 |`KAFKA_CLUSTERS_0_JMXUSERNAME` |Username for JMX authentication
 |`KAFKA_CLUSTERS_0_JMXPASSWORD` |Password for JMX authentication

--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/service/AdminClientServiceImpl.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/service/AdminClientServiceImpl.java
@@ -20,7 +20,7 @@ import reactor.core.publisher.Mono;
 public class AdminClientServiceImpl implements AdminClientService, Closeable {
   private final Map<String, ReactiveAdminClient> adminClientCache = new ConcurrentHashMap<>();
   @Setter // used in tests
-  @Value("${kafka.admin-client-timeout}")
+  @Value("${kafka.admin-client-timeout:30000}")
   private int clientTimeout;
 
   @Override

--- a/kafka-ui-api/src/main/resources/application-local.yml
+++ b/kafka-ui-api/src/main/resources/application-local.yml
@@ -27,9 +27,6 @@ kafka:
   #      protobufMessageNameByTopic:
   #        input-topic: InputMessage
   #        output-topic: OutputMessage
-  admin-client-timeout: 5000
-zookeeper:
-  connection-timeout: 1000
 spring:
   jmx:
     enabled: true

--- a/kafka-ui-api/src/main/resources/application-sdp.yml
+++ b/kafka-ui-api/src/main/resources/application-sdp.yml
@@ -11,6 +11,3 @@ kafka:
   #      zookeeper: zookeeper1:2181
   #      bootstrapServers: kafka1:29092
   #      schemaRegistry: http://schemaregistry1:8085
-  admin-client-timeout: 5000
-zookeeper:
-  connection-timeout: 1000

--- a/kafka-ui-api/src/main/resources/application.yml
+++ b/kafka-ui-api/src/main/resources/application.yml
@@ -1,7 +1,3 @@
-kafka:
-  admin-client-timeout: 5000
-zookeeper:
-  connection-timeout: 1000
 auth:
   enabled: false
 management:
@@ -14,3 +10,6 @@ management:
     web:
       exposure:
         include: "info,health"
+#spring:
+#  main:
+#    allow-bean-definition-overriding=true:

--- a/kafka-ui-api/src/main/resources/application.yml
+++ b/kafka-ui-api/src/main/resources/application.yml
@@ -10,6 +10,3 @@ management:
     web:
       exposure:
         include: "info,health"
-#spring:
-#  main:
-#    allow-bean-definition-overriding=true:

--- a/kafka-ui-api/src/test/resources/application-test.yml
+++ b/kafka-ui-api/src/test/resources/application-test.yml
@@ -6,9 +6,6 @@ kafka:
       zookeeper: localhost:2181
       schemaRegistry: http://localhost:8081
       jmxPort: 9997
-  admin-client-timeout: 5000
-zookeeper:
-  connection-timeout: 1000
 spring:
   jmx:
     enabled: true


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing applications:)
<!-- ignore-task-list-end -->
**What changes did you make?** 

* admin-client-timeout set to 30s by default
* unused zookeeper.connection-timeout removed
* documentation to admin-client-timeout param added
**Is there anything you'd like reviewers to focus on?**

**How Has This Been Tested?** (put an "X" next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [X] Manually(please, describe, when necessary)
- [X] Unit checks
- [X] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "X" next to an item, otherwise PR will fail)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [X] My changes generate no new warnings(e.g. Sonar is happy)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged

Check out [Contributing](https://github.com/provectus/kafka-ui/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/provectus/kafka-ui/blob/master/CODE-OF-CONDUCT.md)