### PR TITLE
Refactoring: cluster storage usage removed from SchemaRegistryService

### DIFF
--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/controller/SchemasController.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/controller/SchemasController.java
@@ -1,8 +1,10 @@
 package com.provectus.kafka.ui.controller;
 
 import com.provectus.kafka.ui.api.SchemasApi;
+import com.provectus.kafka.ui.exception.ValidationException;
 import com.provectus.kafka.ui.model.CompatibilityCheckResponseDTO;
 import com.provectus.kafka.ui.model.CompatibilityLevelDTO;
+import com.provectus.kafka.ui.model.KafkaCluster;
 import com.provectus.kafka.ui.model.NewSchemaSubjectDTO;
 import com.provectus.kafka.ui.model.SchemaSubjectDTO;
 import com.provectus.kafka.ui.service.SchemaRegistryService;
@@ -18,15 +20,25 @@ import reactor.core.publisher.Mono;
 @RestController
 @RequiredArgsConstructor
 @Log4j2
-public class SchemasController implements SchemasApi {
+public class SchemasController extends AbstractController implements SchemasApi {
 
   private final SchemaRegistryService schemaRegistryService;
+
+  @Override
+  protected KafkaCluster getCluster(String clusterName) {
+    var c = super.getCluster(clusterName);
+    if (c.getSchemaRegistry() == null) {
+      throw new ValidationException("Schema Registry is not set for cluster " + clusterName);
+    }
+    return c;
+  }
 
   @Override
   public Mono<ResponseEntity<CompatibilityCheckResponseDTO>> checkSchemaCompatibility(
       String clusterName, String subject, @Valid Mono<NewSchemaSubjectDTO> newSchemaSubject,
       ServerWebExchange exchange) {
-    return schemaRegistryService.checksSchemaCompatibility(clusterName, subject, newSchemaSubject)
+    return schemaRegistryService.checksSchemaCompatibility(
+            getCluster(clusterName), subject, newSchemaSubject)
         .map(ResponseEntity::ok);
   }
 
@@ -35,40 +47,41 @@ public class SchemasController implements SchemasApi {
       String clusterName, @Valid Mono<NewSchemaSubjectDTO> newSchemaSubject,
       ServerWebExchange exchange) {
     return schemaRegistryService
-        .registerNewSchema(clusterName, newSchemaSubject)
+        .registerNewSchema(getCluster(clusterName), newSchemaSubject)
         .map(ResponseEntity::ok);
   }
 
   @Override
   public Mono<ResponseEntity<Void>> deleteLatestSchema(
       String clusterName, String subject, ServerWebExchange exchange) {
-    return schemaRegistryService.deleteLatestSchemaSubject(clusterName, subject);
+    return schemaRegistryService.deleteLatestSchemaSubject(getCluster(clusterName), subject);
   }
 
   @Override
   public Mono<ResponseEntity<Void>> deleteSchema(
       String clusterName, String subjectName, ServerWebExchange exchange) {
-    return schemaRegistryService.deleteSchemaSubjectEntirely(clusterName, subjectName);
+    return schemaRegistryService.deleteSchemaSubjectEntirely(getCluster(clusterName), subjectName);
   }
 
   @Override
   public Mono<ResponseEntity<Void>> deleteSchemaByVersion(
       String clusterName, String subjectName, Integer version, ServerWebExchange exchange) {
-    return schemaRegistryService.deleteSchemaSubjectByVersion(clusterName, subjectName, version);
+    return schemaRegistryService.deleteSchemaSubjectByVersion(
+        getCluster(clusterName), subjectName, version);
   }
 
   @Override
   public Mono<ResponseEntity<Flux<SchemaSubjectDTO>>> getAllVersionsBySubject(
       String clusterName, String subjectName, ServerWebExchange exchange) {
     Flux<SchemaSubjectDTO> schemas =
-        schemaRegistryService.getAllVersionsBySubject(clusterName, subjectName);
+        schemaRegistryService.getAllVersionsBySubject(getCluster(clusterName), subjectName);
     return Mono.just(ResponseEntity.ok(schemas));
   }
 
   @Override
   public Mono<ResponseEntity<CompatibilityLevelDTO>> getGlobalSchemaCompatibilityLevel(
       String clusterName, ServerWebExchange exchange) {
-    return schemaRegistryService.getGlobalSchemaCompatibilityLevel(clusterName)
+    return schemaRegistryService.getGlobalSchemaCompatibilityLevel(getCluster(clusterName))
         .map(ResponseEntity::ok)
         .defaultIfEmpty(ResponseEntity.notFound().build());
   }
@@ -76,21 +89,24 @@ public class SchemasController implements SchemasApi {
   @Override
   public Mono<ResponseEntity<SchemaSubjectDTO>> getLatestSchema(String clusterName, String subject,
                                                              ServerWebExchange exchange) {
-    return schemaRegistryService.getLatestSchemaVersionBySubject(clusterName, subject)
+    return schemaRegistryService.getLatestSchemaVersionBySubject(getCluster(clusterName), subject)
         .map(ResponseEntity::ok);
   }
 
   @Override
   public Mono<ResponseEntity<SchemaSubjectDTO>> getSchemaByVersion(
       String clusterName, String subject, Integer version, ServerWebExchange exchange) {
-    return schemaRegistryService.getSchemaSubjectByVersion(clusterName, subject, version)
+    return schemaRegistryService.getSchemaSubjectByVersion(
+        getCluster(clusterName), subject, version)
         .map(ResponseEntity::ok);
   }
 
   @Override
   public Mono<ResponseEntity<Flux<SchemaSubjectDTO>>> getSchemas(String clusterName,
                                                               ServerWebExchange exchange) {
-    Flux<SchemaSubjectDTO> subjects = schemaRegistryService.getAllLatestVersionSchemas(clusterName);
+    Flux<SchemaSubjectDTO> subjects = schemaRegistryService.getAllLatestVersionSchemas(
+        getCluster(clusterName)
+    );
     return Mono.just(ResponseEntity.ok(subjects));
   }
 
@@ -99,7 +115,8 @@ public class SchemasController implements SchemasApi {
       String clusterName, @Valid Mono<CompatibilityLevelDTO> compatibilityLevel,
       ServerWebExchange exchange) {
     log.info("Updating schema compatibility globally");
-    return schemaRegistryService.updateSchemaCompatibility(clusterName, compatibilityLevel)
+    return schemaRegistryService.updateSchemaCompatibility(
+        getCluster(clusterName), compatibilityLevel)
         .map(ResponseEntity::ok);
   }
 
@@ -108,7 +125,8 @@ public class SchemasController implements SchemasApi {
       String clusterName, String subject, @Valid Mono<CompatibilityLevelDTO> compatibilityLevel,
       ServerWebExchange exchange) {
     log.info("Updating schema compatibility for subject: {}", subject);
-    return schemaRegistryService.updateSchemaCompatibility(clusterName, subject, compatibilityLevel)
+    return schemaRegistryService.updateSchemaCompatibility(
+        getCluster(clusterName), subject, compatibilityLevel)
         .map(ResponseEntity::ok);
   }
 }


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing applications:)
<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)
cluster storage usage removed from SchemaRegistryService
**Is there anything you'd like reviewers to focus on?**


**How Has This Been Tested?** (put an "X" next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [X] Manually(please, describe, when necessary)
- [X] Unit checks
- [ ] Integration checks
- [X] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "X" next to an item, otherwise PR will fail)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [X] My changes generate no new warnings(e.g. Sonar is happy)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged

Check out [Contributing](https://github.com/provectus/kafka-ui/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/provectus/kafka-ui/blob/master/CODE-OF-CONDUCT.md)