### PR TITLE
Bugfix/issue 1250 schema registry back compatibility

### DIFF
--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/exception/SchemaTypeIsNotSupportedException.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/exception/SchemaTypeIsNotSupportedException.java
@@ -1,8 +1,8 @@
 package com.provectus.kafka.ui.exception;
 
-public class SchemaTypeIsNotSupportedException extends UnprocessableEntityException{
+public class SchemaTypeIsNotSupportedException extends UnprocessableEntityException {
 
-    public SchemaTypeIsNotSupportedException() {
-        super("Current version of Schema Registry does not support provided schema type");
-    }
+  public SchemaTypeIsNotSupportedException() {
+    super("Current version of Schema Registry does not support provided schema type");
+  }
 }

--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/exception/SchemaTypeIsNotSupportedException.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/exception/SchemaTypeIsNotSupportedException.java
@@ -2,7 +2,11 @@ package com.provectus.kafka.ui.exception;
 
 public class SchemaTypeIsNotSupportedException extends UnprocessableEntityException {
 
+  private static final String REQUIRED_SCHEMA_REGISTRY_VERSION = "5.5.0";
+
   public SchemaTypeIsNotSupportedException() {
-    super("Current version of Schema Registry does not support provided schema type");
+    super(String.format("Current version of Schema Registry does "
+            + "not support provided schema type,"
+            + " version %s or later is required here.", REQUIRED_SCHEMA_REGISTRY_VERSION));
   }
 }

--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/exception/SchemaTypeIsNotSupportedException.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/exception/SchemaTypeIsNotSupportedException.java
@@ -1,0 +1,8 @@
+package com.provectus.kafka.ui.exception;
+
+public class SchemaTypeIsNotSupportedException extends UnprocessableEntityException{
+
+    public SchemaTypeIsNotSupportedException() {
+        super("Current version of Schema Registry does not support provided schema type");
+    }
+}

--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/service/SchemaRegistryService.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/service/SchemaRegistryService.java
@@ -6,9 +6,9 @@ import static org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY;
 import com.provectus.kafka.ui.exception.ClusterNotFoundException;
 import com.provectus.kafka.ui.exception.DuplicateEntityException;
 import com.provectus.kafka.ui.exception.SchemaNotFoundException;
+import com.provectus.kafka.ui.exception.SchemaTypeIsNotSupportedException;
 import com.provectus.kafka.ui.exception.UnprocessableEntityException;
 import com.provectus.kafka.ui.exception.ValidationException;
-import com.provectus.kafka.ui.exception.SchemaTypeIsNotSupportedException;
 import com.provectus.kafka.ui.mapper.ClusterMapper;
 import com.provectus.kafka.ui.model.CompatibilityCheckResponseDTO;
 import com.provectus.kafka.ui.model.CompatibilityLevelDTO;
@@ -53,7 +53,7 @@ public class SchemaRegistryService {
   private static final String URL_SUBJECT_BY_VERSION = "/subjects/{schemaName}/versions/{version}";
   private static final String LATEST = "latest";
 
-  private static final String ERROR_MESSAGE_UNRECOGNIZED_FIELD_SCHEMA_TYPE = "Unrecognized field: schemaType";
+  private static final String UNRECOGNIZED_FIELD_SCHEMA_TYPE = "Unrecognized field: schemaType";
 
   private final ClustersStorage clustersStorage;
   private final ClusterMapper mapper;
@@ -216,8 +216,9 @@ public class SchemaRegistryService {
         .retrieve()
         .onStatus(UNPROCESSABLE_ENTITY::equals,
             r -> r.bodyToMono(ErrorResponse.class)
-                .flatMap(x -> Mono.error(isUnrecognizedFieldSchemaTypeMessage(x.getMessage()) ?
-                        new SchemaTypeIsNotSupportedException() : new UnprocessableEntityException(x.getMessage()))))
+                .flatMap(x -> Mono.error(isUnrecognizedFieldSchemaTypeMessage(x.getMessage())
+                        ? new SchemaTypeIsNotSupportedException()
+                        : new UnprocessableEntityException(x.getMessage()))))
         .bodyToMono(SubjectIdResponse.class);
   }
 
@@ -235,8 +236,9 @@ public class SchemaRegistryService {
         .onStatus(NOT_FOUND::equals, res -> Mono.empty())
         .onStatus(UNPROCESSABLE_ENTITY::equals,
             r -> r.bodyToMono(ErrorResponse.class)
-                .flatMap(x -> Mono.error(isUnrecognizedFieldSchemaTypeMessage(x.getMessage()) ?
-                        new SchemaTypeIsNotSupportedException() : new UnprocessableEntityException(x.getMessage()))))
+                .flatMap(x -> Mono.error(isUnrecognizedFieldSchemaTypeMessage(x.getMessage())
+                        ? new SchemaTypeIsNotSupportedException()
+                        : new UnprocessableEntityException(x.getMessage()))))
         .bodyToMono(SchemaSubjectDTO.class)
         .filter(s -> Objects.isNull(s.getId()))
         .switchIfEmpty(Mono.error(new DuplicateEntityException("Such schema already exists")));
@@ -355,6 +357,6 @@ public class SchemaRegistryService {
   }
 
   private boolean isUnrecognizedFieldSchemaTypeMessage(String errorMessage) {
-    return errorMessage.contains(ERROR_MESSAGE_UNRECOGNIZED_FIELD_SCHEMA_TYPE);
+    return errorMessage.contains(UNRECOGNIZED_FIELD_SCHEMA_TYPE);
   }
 }


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing applications:)
<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)
As far as different versions of Schema Registry have different sets of parameters for the same endpoint(create new schema endpoint, version less than 5.5 does not support protobuf and json schema types), we have to handle the case when the user tries to create protobuf/json schema via Schema Registry less than 5.5 version.  
In this approach, we intercept errors that contains specific to this case message and wrap them into more readable exceptions.
**Is there anything you'd like reviewers to focus on?**


**How Has This Been Tested?** (put an "X" next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [X] Manually(please, describe, when necessary)
- [ ] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "X" next to an item, otherwise PR will fail)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [X] My changes generate no new warnings(e.g. Sonar is happy)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged

Check out [Contributing](https://github.com/provectus/kafka-ui/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/provectus/kafka-ui/blob/master/CODE-OF-CONDUCT.md)