### PR TITLE
fixing empty screen issue when opening edit schema for proto type

### DIFF
--- a/kafka-ui-react-app/src/components/Schemas/Edit/Edit.tsx
+++ b/kafka-ui-react-app/src/components/Schemas/Edit/Edit.tsx
@@ -37,10 +37,11 @@ const Edit: React.FC = () => {
 
   const schema = useAppSelector((state) => selectSchemaById(state, subject));
 
-  const formatedSchema = React.useMemo(
-    () => JSON.stringify(JSON.parse(schema?.schema || '{}'), null, '\t'),
-    [schema]
-  );
+  const formatedSchema = React.useMemo(() => {
+    return schema?.schemaType === 'PROTOBUF'
+      ? schema?.schema
+      : JSON.stringify(JSON.parse(schema?.schema || '{}'), null, '\t');
+  }, [schema]);
 
   const onSubmit = React.useCallback(async (props: NewSchemaSubjectRaw) => {
     if (!schema) return;

--- a/kafka-ui-react-app/src/components/Schemas/Edit/Edit.tsx
+++ b/kafka-ui-react-app/src/components/Schemas/Edit/Edit.tsx
@@ -38,7 +38,7 @@ const Edit: React.FC = () => {
   const schema = useAppSelector((state) => selectSchemaById(state, subject));
 
   const formatedSchema = React.useMemo(() => {
-    return schema?.schemaType === 'PROTOBUF'
+    return schema?.schemaType === SchemaType.PROTOBUF
       ? schema?.schema
       : JSON.stringify(JSON.parse(schema?.schema || '{}'), null, '\t');
   }, [schema]);


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing applications:)
<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)
Issues #1388 
I have added condition for checking schema type to be able to open edit schema page for proto type.
**Is there anything you'd like reviewers to focus on?**


**How Has This Been Tested?** (put an "X" next to an item)
<!-- ignore-task-list-start -->
- [x] No need to
- [x] Manually(please, describe, when necessary)
- [x] Unit checks
- [x] Integration checks
- [x] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "X" next to an item, otherwise PR will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings(e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/provectus/kafka-ui/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/provectus/kafka-ui/blob/master/CODE-OF-CONDUCT.md)