### PR TITLE
get rid of direct use of colors map

### DIFF
--- a/kafka-ui-react-app/src/components/Connect/Details/Config/Config.tsx
+++ b/kafka-ui-react-app/src/components/Connect/Details/Config/Config.tsx
@@ -9,7 +9,6 @@ import {
 import PageLoader from 'components/common/PageLoader/PageLoader';
 import JSONEditor from 'components/common/JSONEditor/JSONEditor';
 import styled from 'styled-components';
-import { Colors } from 'theme/theme';
 
 interface RouterParams {
   clusterName: ClusterName;
@@ -31,7 +30,7 @@ export interface ConfigProps {
 const ConnectConfigWrapper = styled.div`
   padding: 16px;
   margin: 16px;
-  border: 1px solid ${Colors.neutral[10]};
+  border: 1px solid ${({ theme }) => theme.layout.mainColor};
   border-radius: 8px;
 `;
 

--- a/kafka-ui-react-app/src/components/Connect/Details/Tasks/__tests__/__snapshots__/Tasks.spec.tsx.snap
+++ b/kafka-ui-react-app/src/components/Connect/Details/Tasks/__tests__/__snapshots__/Tasks.spec.tsx.snap
@@ -15,7 +15,7 @@ exports[`Tasks view matches snapshot 1`] = `
 }
 
 .c0 tbody > tr:hover {
-  background-color: #F1F2F3;
+  background-color: hover:#F1F2F3;
 }
 
 .c2 {
@@ -176,7 +176,7 @@ exports[`Tasks view matches snapshot when no tasks 1`] = `
 }
 
 .c0 tbody > tr:hover {
-  background-color: #F1F2F3;
+  background-color: hover:#F1F2F3;
 }
 
 .c2 {

--- a/kafka-ui-react-app/src/components/Connect/List/__tests__/__snapshots__/ListItem.spec.tsx.snap
+++ b/kafka-ui-react-app/src/components/Connect/List/__tests__/__snapshots__/ListItem.spec.tsx.snap
@@ -61,7 +61,7 @@ exports[`Connectors ListItem matches snapshot 1`] = `
 }
 
 .c0 > a {
-  color: #171A1C;
+  color: normal:#171A1C;
   font-weight: 500;
   text-overflow: ellipsis;
 }
@@ -88,6 +88,11 @@ exports[`Connectors ListItem matches snapshot 1`] = `
         },
       },
       "buttonStyles": Object {
+        "border": Object {
+          "active": "#171A1C",
+          "hover": "#454F54",
+          "normal": "#73848C",
+        },
         "fontSize": Object {
           "L": "16px",
           "M": "14px",
@@ -139,6 +144,32 @@ exports[`Connectors ListItem matches snapshot 1`] = `
           "fontSize": "14px",
         },
       },
+      "inputStyles": Object {
+        "backgroundColor": Object {
+          "readOnly": "#F1F2F3",
+        },
+        "borderColor": Object {
+          "disabled": "#E3E6E8",
+          "focus": "#454F54",
+          "hover": "#73848C",
+          "normal": "#ABB5BA",
+        },
+        "color": Object {
+          "disabled": "#ABB5BA",
+          "placeholder": Object {
+            "normal": "#ABB5BA",
+            "readOnly": "#ABB5BA",
+          },
+          "readOnly": "#171A1C",
+        },
+        "error": "#E51A1A",
+        "icon": Object {
+          "color": "#454F54",
+        },
+        "label": Object {
+          "color": "#454F54",
+        },
+      },
       "layout": Object {
         "mainColor": "#F1F2F3",
         "minWidth": "1200px",
@@ -171,6 +202,13 @@ exports[`Connectors ListItem matches snapshot 1`] = `
           "warningTextColor": "#E51A1A",
         },
       },
+      "modalStyles": Object {
+        "backgroundColor": "#FFFFFF",
+        "border": Object {
+          "bottom": "#F1F2F3",
+          "top": "#F1F2F3",
+        },
+      },
       "pageLoader": Object {
         "borderBottomColor": "#FFFFFF",
         "borderColor": "#4F4FFF",
@@ -196,6 +234,7 @@ exports[`Connectors ListItem matches snapshot 1`] = `
         "borderColor": Object {
           "active": "#4F4FFF",
           "hover": "transparent",
+          "nav": "#E3E6E8",
           "normal": "transparent",
         },
         "color": Object {
@@ -244,6 +283,36 @@ exports[`Connectors ListItem matches snapshot 1`] = `
         "checked": "#29A352",
         "unchecked": "#ABB5BA",
       },
+      "tableStyles": Object {
+        "link": Object {
+          "color": Object {
+            "normal": "#171A1C",
+          },
+        },
+        "tdStyles": Object {
+          "color": Object {
+            "normal": "#171A1C",
+          },
+        },
+        "thStyles": Object {
+          "backgroundColor": Object {
+            "normal": "#FFFFFF",
+          },
+          "color": Object {
+            "active": "#4F4FFF",
+            "hover": "#4F4FFF",
+            "normal": "#73848C",
+          },
+          "previewColor": Object {
+            "normal": "#4F4FFF",
+          },
+        },
+        "trStyles": Object {
+          "backgroundColor": Object {
+            "hover": "#F1F2F3",
+          },
+        },
+      },
       "tagStyles": Object {
         "backgroundColor": Object {
           "blue": "#e3f2fd",
@@ -255,17 +324,23 @@ exports[`Connectors ListItem matches snapshot 1`] = `
         },
         "color": "#171A1C",
       },
-      "thStyles": Object {
+      "textAreaStyles": Object {
         "backgroundColor": Object {
-          "normal": "#FFFFFF",
+          "readOnly": "#F1F2F3",
+        },
+        "borderColor": Object {
+          "disabled": "#E3E6E8",
+          "focus": "#454F54",
+          "hover": "#73848C",
+          "normal": "#ABB5BA",
         },
         "color": Object {
-          "active": "#4F4FFF",
-          "hover": "#4F4FFF",
-          "normal": "#73848C",
-        },
-        "previewColor": Object {
-          "normal": "#4F4FFF",
+          "disabled": "#ABB5BA",
+          "placeholder": Object {
+            "normal": "#ABB5BA",
+            "readOnly": "#ABB5BA",
+          },
+          "readOnly": "#171A1C",
         },
       },
     }

--- a/kafka-ui-react-app/src/components/Topics/Topic/Details/__test__/__snapshots__/Details.spec.tsx.snap
+++ b/kafka-ui-react-app/src/components/Topics/Topic/Details/__test__/__snapshots__/Details.spec.tsx.snap
@@ -99,6 +99,11 @@ exports[`Details when it has readonly flag does not render the Action button a T
         },
       },
       "buttonStyles": Object {
+        "border": Object {
+          "active": "#171A1C",
+          "hover": "#454F54",
+          "normal": "#73848C",
+        },
         "fontSize": Object {
           "L": "16px",
           "M": "14px",
@@ -150,6 +155,32 @@ exports[`Details when it has readonly flag does not render the Action button a T
           "fontSize": "14px",
         },
       },
+      "inputStyles": Object {
+        "backgroundColor": Object {
+          "readOnly": "#F1F2F3",
+        },
+        "borderColor": Object {
+          "disabled": "#E3E6E8",
+          "focus": "#454F54",
+          "hover": "#73848C",
+          "normal": "#ABB5BA",
+        },
+        "color": Object {
+          "disabled": "#ABB5BA",
+          "placeholder": Object {
+            "normal": "#ABB5BA",
+            "readOnly": "#ABB5BA",
+          },
+          "readOnly": "#171A1C",
+        },
+        "error": "#E51A1A",
+        "icon": Object {
+          "color": "#454F54",
+        },
+        "label": Object {
+          "color": "#454F54",
+        },
+      },
       "layout": Object {
         "mainColor": "#F1F2F3",
         "minWidth": "1200px",
@@ -182,6 +213,13 @@ exports[`Details when it has readonly flag does not render the Action button a T
           "warningTextColor": "#E51A1A",
         },
       },
+      "modalStyles": Object {
+        "backgroundColor": "#FFFFFF",
+        "border": Object {
+          "bottom": "#F1F2F3",
+          "top": "#F1F2F3",
+        },
+      },
       "pageLoader": Object {
         "borderBottomColor": "#FFFFFF",
         "borderColor": "#4F4FFF",
@@ -207,6 +245,7 @@ exports[`Details when it has readonly flag does not render the Action button a T
         "borderColor": Object {
           "active": "#4F4FFF",
           "hover": "transparent",
+          "nav": "#E3E6E8",
           "normal": "transparent",
         },
         "color": Object {
@@ -255,6 +294,36 @@ exports[`Details when it has readonly flag does not render the Action button a T
         "checked": "#29A352",
         "unchecked": "#ABB5BA",
       },
+      "tableStyles": Object {
+        "link": Object {
+          "color": Object {
+            "normal": "#171A1C",
+          },
+        },
+        "tdStyles": Object {
+          "color": Object {
+            "normal": "#171A1C",
+          },
+        },
+        "thStyles": Object {
+          "backgroundColor": Object {
+            "normal": "#FFFFFF",
+          },
+          "color": Object {
+            "active": "#4F4FFF",
+            "hover": "#4F4FFF",
+            "normal": "#73848C",
+          },
+          "previewColor": Object {
+            "normal": "#4F4FFF",
+          },
+        },
+        "trStyles": Object {
+          "backgroundColor": Object {
+            "hover": "#F1F2F3",
+          },
+        },
+      },
       "tagStyles": Object {
         "backgroundColor": Object {
           "blue": "#e3f2fd",
@@ -266,17 +335,23 @@ exports[`Details when it has readonly flag does not render the Action button a T
         },
         "color": "#171A1C",
       },
-      "thStyles": Object {
+      "textAreaStyles": Object {
         "backgroundColor": Object {
-          "normal": "#FFFFFF",
+          "readOnly": "#F1F2F3",
+        },
+        "borderColor": Object {
+          "disabled": "#E3E6E8",
+          "focus": "#454F54",
+          "hover": "#73848C",
+          "normal": "#ABB5BA",
         },
         "color": Object {
-          "active": "#4F4FFF",
-          "hover": "#4F4FFF",
-          "normal": "#73848C",
-        },
-        "previewColor": Object {
-          "normal": "#4F4FFF",
+          "disabled": "#ABB5BA",
+          "placeholder": Object {
+            "normal": "#ABB5BA",
+            "readOnly": "#ABB5BA",
+          },
+          "readOnly": "#171A1C",
         },
       },
     }

--- a/kafka-ui-react-app/src/components/Topics/shared/Form/TimeToRetainBtn.styled.ts
+++ b/kafka-ui-react-app/src/components/Topics/shared/Form/TimeToRetainBtn.styled.ts
@@ -1,0 +1,19 @@
+import styled from 'styled-components';
+
+export const TimeToRetainBtnStyled = styled.button<{ isActive: boolean }>`
+  background-color: ${({ theme, ...props }) =>
+    props.isActive
+      ? theme.buttonStyles.primary.backgroundColor.active
+      : theme.buttonStyles.primary.color};
+  height: 32px;
+  width: 46px;
+  border: 1px solid
+    ${({ theme, ...props }) =>
+      props.isActive
+        ? theme.buttonStyles.border.active
+        : theme.buttonStyles.primary.color};
+  border-radius: 6px;
+  &:hover {
+    cursor: pointer;
+  }
+`;

--- a/kafka-ui-react-app/src/components/Topics/shared/Form/TimeToRetainBtn.tsx
+++ b/kafka-ui-react-app/src/components/Topics/shared/Form/TimeToRetainBtn.tsx
@@ -1,27 +1,14 @@
 import React from 'react';
 import { useFormContext } from 'react-hook-form';
 import { MILLISECONDS_IN_WEEK } from 'lib/constants';
-import styled from 'styled-components';
-import { Colors } from 'theme/theme';
+
+import { TimeToRetainBtnStyled } from './TimeToRetainBtn.styled';
 
 interface Props {
   inputName: string;
   text: string;
   value: number;
 }
-
-const TimeToRetainBtnStyled = styled.button<{ isActive: boolean }>`
-  background-color: ${(props) =>
-    props.isActive ? Colors.neutral[10] : Colors.neutral[0]};
-  height: 32px;
-  width: 46px;
-  border: 1px solid
-    ${(props) => (props.isActive ? Colors.neutral[90] : Colors.neutral[40])};
-  border-radius: 6px;
-  &:hover {
-    cursor: pointer;
-  }
-`;
 
 const TimeToRetainBtn: React.FC<Props> = ({ inputName, text, value }) => {
   const { setValue, watch } = useFormContext();

--- a/kafka-ui-react-app/src/components/common/ConfirmationModal/ConfirmationModal.styled.tsx
+++ b/kafka-ui-react-app/src/components/common/ConfirmationModal/ConfirmationModal.styled.tsx
@@ -1,5 +1,4 @@
 import styled from 'styled-components';
-import { Colors } from 'theme/theme';
 
 export const ConfirmationModalWrapper = styled.div.attrs({ role: 'dialog' })`
   display: flex;
@@ -29,7 +28,7 @@ export const ConfirmationModalWrapper = styled.div.attrs({ role: 'dialog' })`
     width: 560px;
     border-radius: 8px;
 
-    background-color: ${Colors.neutral[0]};
+    background-color: ${({ theme }) => theme.modalStyles.backgroundColor};
     filter: drop-shadow(0px 4px 16px rgba(0, 0, 0, 0.1));
 
     & > * {
@@ -44,8 +43,8 @@ export const ConfirmationModalWrapper = styled.div.attrs({ role: 'dialog' })`
     }
 
     & > section {
-      border-top: 1px solid ${Colors.neutral[5]};
-      border-bottom: 1px solid ${Colors.neutral[5]};
+      border-top: 1px solid ${({ theme }) => theme.modalStyles.border.top};
+      border-bottom: 1px solid ${({ theme }) => theme.modalStyles.border.bottom};
     }
 
     & > footer {

--- a/kafka-ui-react-app/src/components/common/Input/Input.styled.ts
+++ b/kafka-ui-react-app/src/components/common/Input/Input.styled.ts
@@ -1,5 +1,4 @@
 import styled from 'styled-components';
-import { Colors } from 'theme/theme';
 
 export interface InputProps {
   inputSize?: 'M' | 'L';
@@ -7,7 +6,7 @@ export interface InputProps {
 }
 
 export const Input = styled.input<InputProps>`
-  border: 1px ${Colors.neutral[30]} solid;
+  border: 1px ${({ theme }) => theme.inputStyles.borderColor.normal} solid;
   border-radius: 4px;
   height: ${(props) => (props.inputSize === 'M' ? '32px' : '40px')};
   width: 100%;
@@ -15,31 +14,32 @@ export const Input = styled.input<InputProps>`
   font-size: 14px;
 
   &::placeholder {
-    color: ${Colors.neutral[30]};
+    color: ${({ theme }) => theme.inputStyles.color.placeholder.normal};
     font-size: 14px;
   }
   &:hover {
-    border-color: ${Colors.neutral[50]};
+    border-color: ${({ theme }) => theme.inputStyles.borderColor.hover};
   }
   &:focus {
     outline: none;
-    border-color: ${Colors.neutral[70]};
+    border-color: ${({ theme }) => theme.inputStyles.borderColor.focus};
     &::placeholder {
       color: transparent;
     }
   }
   &:disabled {
-    color: ${Colors.neutral[30]};
-    border-color: ${Colors.neutral[10]};
+    color: ${({ theme }) => theme.inputStyles.color.disabled};
+    border-color: ${({ theme }) => theme.inputStyles.borderColor.disabled};
     cursor: not-allowed;
   }
   &:read-only {
-    color: ${Colors.neutral[90]};
+    color: ${({ theme }) => theme.inputStyles.color.readOnly};
     border: none;
-    background-color: ${Colors.neutral[5]};
+    background-color: ${({ theme }) =>
+      theme.inputStyles.backgroundColor.readOnly};
     &:focus {
       &::placeholder {
-        color: ${Colors.neutral[30]};
+        color: ${({ theme }) => theme.inputStyles.color.placeholder.readOnly};
       }
     }
     cursor: not-allowed;
@@ -47,6 +47,6 @@ export const Input = styled.input<InputProps>`
 `;
 
 export const FormError = styled.p`
-  color: ${Colors.red[50]};
+  color: ${({ theme }) => theme.inputStyles.error};
   font-size: 12px;
 `;

--- a/kafka-ui-react-app/src/components/common/Input/InputIcon.styled.ts
+++ b/kafka-ui-react-app/src/components/common/Input/InputIcon.styled.ts
@@ -1,5 +1,4 @@
 import styled from 'styled-components';
-import { Colors } from 'theme/theme';
 
 interface Props {
   className: string;
@@ -16,5 +15,5 @@ export const InputIcon = styled.i<Props>`
   right: ${(props) => (props.position === 'right' ? '15px' : 'unset')};
   height: 11px;
   width: 11px;
-  color: ${Colors.neutral[70]};
+  color: ${({ theme }) => theme.inputStyles.icon.color};
 `;

--- a/kafka-ui-react-app/src/components/common/Input/InputLabel.styled.ts
+++ b/kafka-ui-react-app/src/components/common/Input/InputLabel.styled.ts
@@ -1,9 +1,8 @@
 import styled from 'styled-components';
-import { Colors } from 'theme/theme';
 
 export const InputLabel = styled.label`
   font-weight: 500;
   font-size: 12px;
   line-height: 20px;
-  color: ${Colors.neutral[70]};
+  color: ${({ theme }) => theme.inputStyles.label.color};
 `;

--- a/kafka-ui-react-app/src/components/common/Navigation/Navbar.styled.ts
+++ b/kafka-ui-react-app/src/components/common/Navigation/Navbar.styled.ts
@@ -1,9 +1,9 @@
 import styled from 'styled-components';
-import { Colors } from 'theme/theme';
 
 const Navbar = styled.nav`
   display: flex;
-  border-bottom: 1px ${Colors.neutral[10]} solid;
+  border-bottom: 1px ${({ theme }) => theme.primaryTabStyles.borderColor.nav}
+    solid;
   & a {
     height: 40px;
     width: 96px;

--- a/kafka-ui-react-app/src/components/common/Textbox/Textarea.styled.ts
+++ b/kafka-ui-react-app/src/components/common/Textbox/Textarea.styled.ts
@@ -1,39 +1,40 @@
 import styled from 'styled-components';
-import { Colors } from 'theme/theme';
 
 export const Textarea = styled.textarea`
-  border: 1px ${Colors.neutral[30]} solid;
+  border: 1px ${({ theme }) => theme.textAreaStyles.borderColor.normal} solid;
   border-radius: 4px;
   width: 100%;
   padding: 12px;
   padding-top: 6px;
 
   &::placeholder {
-    color: ${Colors.neutral[30]};
+    color: ${({ theme }) => theme.textAreaStyles.color.placeholder.normal};
     font-size: 14px;
   }
   &:hover {
-    border-color: ${Colors.neutral[50]};
+    border-color: ${({ theme }) => theme.textAreaStyles.borderColor.hover};
   }
   &:focus {
     outline: none;
-    border-color: ${Colors.neutral[70]};
+    border-color: ${({ theme }) => theme.textAreaStyles.borderColor.focus};
     &::placeholder {
       color: transparent;
     }
   }
   &:disabled {
-    color: ${Colors.neutral[30]};
-    border-color: ${Colors.neutral[10]};
+    color: ${({ theme }) => theme.textAreaStyles.color.disabled};
+    border-color: ${({ theme }) => theme.textAreaStyles.borderColor.disabled};
     cursor: not-allowed;
   }
   &:read-only {
-    color: ${Colors.neutral[90]};
+    color: ${({ theme }) => theme.textAreaStyles.color.readOnly};
     border: none;
-    background-color: ${Colors.neutral[5]};
+    background-color: ${({ theme }) =>
+      theme.textAreaStyles.backgroundColor.readOnly};
     &:focus {
       &::placeholder {
-        color: ${Colors.neutral[30]};
+        color: ${({ theme }) =>
+          theme.textAreaStyles.color.placeholder.readOnly};
       }
     }
     cursor: not-allowed;

--- a/kafka-ui-react-app/src/components/common/table/Table/Table.styled.ts
+++ b/kafka-ui-react-app/src/components/common/table/Table/Table.styled.ts
@@ -1,5 +1,4 @@
 import styled from 'styled-components';
-import { Colors } from 'theme/theme';
 
 interface Props {
   isFullwidth?: boolean;
@@ -13,13 +12,14 @@ export const Table = styled.table<Props>`
     font-size: 14px;
     font-weight: 400;
     padding: 8px 8px 8px 24px;
-    color: ${Colors.neutral[90]};
+    color: ${({ theme }) => theme.tableStyles.tdStyles.color.normal};
     vertical-align: middle;
   }
 
   & tbody > tr {
     &:hover {
-      background-color: ${Colors.neutral[5]};
+      background-color: ${({ theme }) =>
+        theme.tableStyles.trStyles.backgroundColor};
     }
   }
 `;

--- a/kafka-ui-react-app/src/components/common/table/Table/TableKeyLink.styled.ts
+++ b/kafka-ui-react-app/src/components/common/table/Table/TableKeyLink.styled.ts
@@ -1,9 +1,8 @@
 import styled from 'styled-components';
-import { Colors } from 'theme/theme';
 
 export const TableKeyLink = styled.td`
   & > a {
-    color: ${Colors.neutral[90]};
+    color: ${({ theme }) => theme.tableStyles.link.color};
     font-weight: 500;
     text-overflow: ellipsis;
   }

--- a/kafka-ui-react-app/src/components/common/table/TableHeaderCell/TableHeaderCell.styled.ts
+++ b/kafka-ui-react-app/src/components/common/table/TableHeaderCell/TableHeaderCell.styled.ts
@@ -9,7 +9,7 @@ const isOrderableStyles = css`
   cursor: pointer;
 
   &:hover {
-    color: ${(props) => props.theme.thStyles.color.hover};
+    color: ${(props) => props.theme.tableStyles.thStyles.color.hover};
   }
 `;
 
@@ -21,11 +21,12 @@ export const Title = styled.span<TitleProps>`
   line-height: 16px;
   letter-spacing: 0em;
   text-align: left;
-  background: ${(props) => props.theme.thStyles.backgroundColor.normal};
+  background: ${(props) =>
+    props.theme.tableStyles.thStyles.backgroundColor.normal};
   color: ${(props) =>
     props.isOrdered
-      ? props.theme.thStyles.color.active
-      : props.theme.thStyles.color.normal};
+      ? props.theme.tableStyles.thStyles.color.active
+      : props.theme.tableStyles.thStyles.color.normal};
   cursor: default;
 
   ${(props) => props.isOrderable && isOrderableStyles}
@@ -39,9 +40,10 @@ export const Preview = styled.span`
   line-height: 16px;
   letter-spacing: 0em;
   text-align: left;
-  background: ${(props) => props.theme.thStyles.backgroundColor.normal};
+  background: ${(props) =>
+    props.theme.tableStyles.thStyles.backgroundColor.normal};
   font-size: 14px;
-  color: ${(props) => props.theme.thStyles.previewColor.normal};
+  color: ${(props) => props.theme.tableStyles.thStyles.previewColor.normal};
   cursor: pointer;
 `;
 

--- a/kafka-ui-react-app/src/theme/theme.ts
+++ b/kafka-ui-react-app/src/theme/theme.ts
@@ -109,6 +109,11 @@ const theme = {
       M: '14px',
       L: '16px',
     },
+    border: {
+      normal: Colors.neutral[50],
+      hover: Colors.neutral[70],
+      active: Colors.neutral[90],
+    },
   },
   menuStyles: {
     backgroundColor: {
@@ -127,17 +132,41 @@ const theme = {
     },
     chevronIconColor: Colors.neutral[50],
   },
-  thStyles: {
-    backgroundColor: {
-      normal: Colors.neutral[0],
+  modalStyles: {
+    backgroundColor: Colors.neutral[0],
+    border: {
+      top: Colors.neutral[5],
+      bottom: Colors.neutral[5],
     },
-    color: {
-      normal: Colors.neutral[50],
-      hover: Colors.brand[50],
-      active: Colors.brand[50],
+  },
+  tableStyles: {
+    thStyles: {
+      backgroundColor: {
+        normal: Colors.neutral[0],
+      },
+      color: {
+        normal: Colors.neutral[50],
+        hover: Colors.brand[50],
+        active: Colors.brand[50],
+      },
+      previewColor: {
+        normal: Colors.brand[50],
+      },
     },
-    previewColor: {
-      normal: Colors.brand[50],
+    tdStyles: {
+      color: {
+        normal: Colors.neutral[90],
+      },
+    },
+    trStyles: {
+      backgroundColor: {
+        hover: Colors.neutral[5],
+      },
+    },
+    link: {
+      color: {
+        normal: Colors.neutral[90],
+      },
     },
   },
   primaryTabStyles: {
@@ -150,6 +179,7 @@ const theme = {
       normal: 'transparent',
       hover: 'transparent',
       active: Colors.brand[50],
+      nav: Colors.neutral[10],
     },
   },
   secondaryTabStyles: {
@@ -176,6 +206,51 @@ const theme = {
       hover: Colors.neutral[50],
       active: Colors.neutral[70],
       disabled: Colors.neutral[10],
+    },
+  },
+  inputStyles: {
+    borderColor: {
+      normal: Colors.neutral[30],
+      hover: Colors.neutral[50],
+      focus: Colors.neutral[70],
+      disabled: Colors.neutral[10],
+    },
+    color: {
+      placeholder: {
+        normal: Colors.neutral[30],
+        readOnly: Colors.neutral[30],
+      },
+      disabled: Colors.neutral[30],
+      readOnly: Colors.neutral[90],
+    },
+    backgroundColor: {
+      readOnly: Colors.neutral[5],
+    },
+    error: Colors.red[50],
+    icon: {
+      color: Colors.neutral[70],
+    },
+    label: {
+      color: Colors.neutral[70],
+    },
+  },
+  textAreaStyles: {
+    borderColor: {
+      normal: Colors.neutral[30],
+      hover: Colors.neutral[50],
+      focus: Colors.neutral[70],
+      disabled: Colors.neutral[10],
+    },
+    color: {
+      placeholder: {
+        normal: Colors.neutral[30],
+        readOnly: Colors.neutral[30],
+      },
+      disabled: Colors.neutral[30],
+      readOnly: Colors.neutral[90],
+    },
+    backgroundColor: {
+      readOnly: Colors.neutral[5],
     },
   },
   tagStyles: {


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing applications:)
<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)

**Is there anything you'd like reviewers to focus on?**


**How Has This Been Tested?** (put an "X" next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [ ] Manually(please, describe, when necessary)
- [ ] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "X" next to an item, otherwise PR will fail)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [ ] My changes generate no new warnings(e.g. Sonar is happy)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

Check out [Contributing](https://github.com/provectus/kafka-ui/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/provectus/kafka-ui/blob/master/CODE-OF-CONDUCT.md)