### PR TITLE
fix update of helm chart on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -97,10 +97,10 @@ jobs:
 
       - uses: azure/setup-helm@v1
 
-      - name: update appVersion
+      - name: update chart version
         run: |
           export version=${{needs.release.outputs.version}}
-          sed -i "s/appVersion:.*/appVersion: ${version}/" charts/kafka-ui/Chart.yaml
+          sed -i "s/version:.*/version: ${version}/" charts/kafka-ui/Chart.yaml
 
       - name: add chart
         run: |


### PR DESCRIPTION
Updating appVersion in Chart.yaml doesn't produce new chart archive with updated version. It still creates the archive of the version specified in version field.

<img width="1098" alt="image" src="https://user-images.githubusercontent.com/94184844/150958294-22706a27-a01b-405d-8f33-a0926b4911ce.png">

In order to produce new archive with updated helm chart by running helm package it's required to substitute the version instead of the appVersion.

<img width="1114" alt="image" src="https://user-images.githubusercontent.com/94184844/150958479-4cad288d-a143-44db-a784-a16222d745f0.png">

