### PR TITLE
Specify distinct image tag version for helm chart

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -109,6 +109,7 @@ jobs:
         run: |
           export version=${{needs.release.outputs.version}}
           sed -i "s/version:.*/version: ${version}/" charts/kafka-ui/Chart.yaml
+          sed -i "s/appVersion:.*/appVersion: ${version}/" charts/kafka-ui/Chart.yaml
 
       - name: add chart
         run: |

--- a/charts/kafka-ui/values.yaml
+++ b/charts/kafka-ui/values.yaml
@@ -5,7 +5,7 @@ image:
   repository: provectuslabs/kafka-ui
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "latest"
+  tag: ""
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
resolves: https://github.com/provectus/kafka-ui/issues/1591

The image is built by this rule:
`image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"`

Solution is to remove image tag from the values.yaml so that a user can specify his own tag if necessary, however, by default the image tag of the version corresponding to the release version is used.
Release version is substituted in release.yaml instead of using constant "latest" appVersion.