### PR TITLE
frontend wf restrict warnings

### DIFF
--- a/.github/workflows/frontend.yaml
+++ b/.github/workflows/frontend.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: Linter
         run: |
           cd kafka-ui-react-app/
-          npm run lint
+          npm run lint:CI
       - name: Tests
         run: |
           cd kafka-ui-react-app/

--- a/kafka-ui-react-app/package.json
+++ b/kafka-ui-react-app/package.json
@@ -55,6 +55,7 @@
     "build": "react-scripts build",
     "lint": "eslint --ext .tsx,.ts src/",
     "lint:fix": "eslint --ext .tsx,.ts src/ --fix",
+    "lint:CI": "eslint --ext .tsx,.ts src/ --max-warnings=0",
     "test": "react-scripts test",
     "test:CI": "CI=true npm test  -- --coverage --ci --testResultsProcessor=\"jest-sonar-reporter\" --watchAll=false",
     "eject": "react-scripts eject",


### PR DESCRIPTION
Now frontend workflow will be triggered with the next param set to 0, what will return non-zero exit code.
`--max-warnings Int   Number of warnings to trigger nonzero exit code - default: -1`


New option to package json is added for CI.
