### PR TITLE
Add clear message when topic creation fails

### DIFF
--- a/kafka-ui-react-app/src/components/Topics/New/New.tsx
+++ b/kafka-ui-react-app/src/components/Topics/New/New.tsx
@@ -40,7 +40,7 @@ const New: React.FC = () => {
       const response = await getResponse(error as Response);
       const alert: FailurePayload = {
         subject: ['schema', data.name].join('-'),
-        title: `Schema ${data.name}`,
+        title: `${response.message}`,
         response,
       };
 


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)

<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)

I changed to display the error message returned from the backend.

**Is there anything you'd like reviewers to focus on?**

It's my first pull request on this project so I'm happy If you give me a feedback. 

**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [ ] Manually (please, describe, if necessary)
- [ ] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [ ] My changes generate no new warnings (e.g. Sonar is happy)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

Check out [Contributing](https://github.com/provectus/kafka-ui/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/provectus/kafka-ui/blob/master/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**
Topic creation when fails display 'Schema <topic'

<img width="1583" alt="image" src="https://user-images.githubusercontent.com/1748946/155448813-3f1c14eb-afbb-4a17-a2d0-3cf569f9fd8e.png">

Now is displaying the error returned from the backend:

<img width="1583" alt="Screen Shot 2022-02-23 at 23 47 21" src="https://user-images.githubusercontent.com/1748946/155448858-91fe9703-4032-4964-b1dd-7567f2d076a1.png">

