### PR TITLE
draft/bugfix/1500 : display correct values when editing topic

### DIFF
--- a/kafka-ui-contract/src/main/resources/swagger/kafka-ui-api.yaml
+++ b/kafka-ui-contract/src/main/resources/swagger/kafka-ui-api.yaml
@@ -2824,7 +2824,7 @@ components:
     CleanUpPolicy:
       type: string
       enum:
-        - DELETE
-        - COMPACT
-        - COMPACT_DELETE
-        - UNKNOWN
+        - delete
+        - compact
+        - compact,delete
+        - unknown

--- a/kafka-ui-react-app/src/components/Topics/List/ListItem.tsx
+++ b/kafka-ui-react-app/src/components/Topics/List/ListItem.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { CleanUpPolicy } from 'generated-sources';
 import {
   ClusterName,
   TopicName,
@@ -112,7 +113,7 @@ const ListItem: React.FC<ListItemProps> = ({
         {!internal && !isReadOnly && vElipsisVisble ? (
           <div className="has-text-right">
             <Dropdown label={<VerticalElipsisIcon />} right>
-              {cleanUpPolicy === 'DELETE' && (
+              {cleanUpPolicy === CleanUpPolicy.DELETE && (
                 <DropdownItem onClick={clearTopicMessagesHandler} danger>
                   Clear Messages
                 </DropdownItem>

--- a/kafka-ui-react-app/src/components/Topics/Topic/Details/Overview/Overview.tsx
+++ b/kafka-ui-react-app/src/components/Topics/Topic/Details/Overview/Overview.tsx
@@ -1,5 +1,9 @@
 import React from 'react';
-import { Topic, TopicDetails } from 'generated-sources';
+import {
+  Topic,
+  TopicDetails,
+  CleanUpPolicy,
+} from 'generated-sources';
 import { ClusterName, TopicName } from 'redux/interfaces';
 import Dropdown from 'components/common/Dropdown/Dropdown';
 import DropdownItem from 'components/common/Dropdown/DropdownItem';
@@ -116,7 +120,7 @@ const Overview: React.FC<Props> = ({
                 <td>{offsetMax}</td>
                 <td>{offsetMax - offsetMin}</td>
                 <td style={{ width: '5%' }}>
-                  {!internal && !isReadOnly && cleanUpPolicy === 'DELETE' ? (
+                  {!internal && !isReadOnly && cleanUpPolicy === CleanUpPolicy.DELETE ? (
                     <Dropdown label={<VerticalElipsisIcon />} right>
                       <DropdownItem
                         onClick={() =>

--- a/kafka-ui-react-app/src/components/Topics/Topic/Edit/Edit.tsx
+++ b/kafka-ui-react-app/src/components/Topics/Topic/Edit/Edit.tsx
@@ -3,7 +3,6 @@ import {
   ClusterName,
   TopicFormDataRaw,
   TopicName,
-  TopicConfigByName,
   TopicWithDetailedInfo,
   TopicFormData,
 } from 'redux/interfaces';
@@ -117,14 +116,6 @@ const Edit: React.FC<Props> = ({
     formInit = true;
   }
 
-  const config: TopicConfigByName = {
-    byName: {},
-  };
-
-  topic.config.forEach((param) => {
-    config.byName[param.name] = param;
-  });
-
   const onSubmit = async (data: TopicFormDataRaw) => {
     updateTopic(clusterName, topicName, data);
     setIsSubmitting(true); // Keep this action after updateTopic to prevent redirect before update.
@@ -137,7 +128,7 @@ const Edit: React.FC<Props> = ({
         <div>
           <FormProvider {...methods}>
             <TopicForm
-              topicName={topicName}
+              topic={topic}
               isSubmitting={isSubmitting}
               isEditing
               onSubmit={methods.handleSubmit(onSubmit)}

--- a/kafka-ui-react-app/src/components/Topics/shared/Form/TimeToRetain.tsx
+++ b/kafka-ui-react-app/src/components/Topics/shared/Form/TimeToRetain.tsx
@@ -12,9 +12,10 @@ import TimeToRetainBtns from './TimeToRetainBtns';
 
 interface Props {
   isSubmitting: boolean;
+  time?: string;
 }
 
-const TimeToRetain: React.FC<Props> = ({ isSubmitting }) => {
+const TimeToRetain: React.FC<Props> = ({ time, isSubmitting }) => {
   const {
     watch,
     formState: { errors },
@@ -39,7 +40,7 @@ const TimeToRetain: React.FC<Props> = ({ isSubmitting }) => {
       <Input
         id="timeToRetain"
         type="number"
-        defaultValue={defaultValue}
+        defaultValue={time ?? defaultValue}
         name={name}
         hookFormOptions={{
           min: { value: -1, message: 'must be greater than or equal to -1' },

--- a/kafka-ui-react-app/src/components/Topics/shared/Form/TopicForm.tsx
+++ b/kafka-ui-react-app/src/components/Topics/shared/Form/TopicForm.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useFormContext, Controller } from 'react-hook-form';
 import { NOT_SET, BYTES_IN_GB } from 'lib/constants';
-import { TopicName } from 'redux/interfaces';
 import { ErrorMessage } from '@hookform/error-message';
 import Select, { SelectOption } from 'components/common/Select/Select';
 import Input from 'components/common/Input/Input';
@@ -9,13 +8,14 @@ import { Button } from 'components/common/Button/Button';
 import { InputLabel } from 'components/common/Input/InputLabel.styled';
 import { FormError } from 'components/common/Input/Input.styled';
 import { StyledForm } from 'components/common/Form/Form.styled';
+import { TopicWithDetailedInfo } from 'redux/interfaces';
 
 import CustomParamsContainer from './CustomParams/CustomParamsContainer';
 import TimeToRetain from './TimeToRetain';
 import * as S from './TopicForm.styled';
 
 export interface Props {
-  topicName?: TopicName;
+  topic?: TopicWithDetailedInfo;
   isEditing?: boolean;
   isSubmitting: boolean;
   onSubmit: (e: React.BaseSyntheticEvent) => Promise<void>;
@@ -36,7 +36,7 @@ const RetentionBytesOptions: Array<SelectOption> = [
 ];
 
 const TopicForm: React.FC<Props> = ({
-  topicName,
+  topic,
   isEditing,
   isSubmitting,
   onSubmit,
@@ -45,6 +45,7 @@ const TopicForm: React.FC<Props> = ({
     control,
     formState: { errors },
   } = useFormContext();
+  console.log(topic?.cleanUpPolicy?.toLowerCase());
   return (
     <StyledForm onSubmit={onSubmit}>
       <fieldset disabled={isSubmitting}>
@@ -56,7 +57,7 @@ const TopicForm: React.FC<Props> = ({
                 id="topicFormName"
                 name="name"
                 placeholder="Topic Name"
-                defaultValue={topicName}
+                defaultValue={topic?.name}
               />
               <FormError>
                 <ErrorMessage errors={errors} name="name" />
@@ -135,7 +136,10 @@ const TopicForm: React.FC<Props> = ({
                   id="topicFormCleanupPolicy"
                   aria-labelledby="topicFormCleanupPolicyLabel"
                   name={name}
-                  value={CleanupPolicyOptions[0].value}
+                  defaultValue={
+                    topic?.cleanUpPolicy?.toLowerCase() ??
+                    CleanupPolicyOptions[0].value
+                  }
                   onChange={onChange}
                   minWidth="250px"
                   options={CleanupPolicyOptions}
@@ -147,7 +151,12 @@ const TopicForm: React.FC<Props> = ({
 
         <S.Column>
           <div>
-            <TimeToRetain isSubmitting={isSubmitting} />
+            <TimeToRetain
+              time={
+                topic?.config?.find((e) => e.name === 'retention.ms')?.value
+              }
+              isSubmitting={isSubmitting}
+            />
           </div>
         </S.Column>
 

--- a/kafka-ui-react-app/src/components/common/Select/Select.tsx
+++ b/kafka-ui-react-app/src/components/common/Select/Select.tsx
@@ -72,7 +72,7 @@ const Select: React.FC<SelectProps> = ({
         {isLive && <LiveIcon />}
         <S.SelectedOption role="option" tabIndex={0}>
           {options.find(
-            (option) => option.value === (defaultValue || selectedOption)
+            (option) => option.value === (selectedOption || defaultValue)
           )?.label || placeholder}
         </S.SelectedOption>
         {showOptions && (


### PR DESCRIPTION
<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)

Made sure cleanup policy was displayed and updated correctly.
Aligned values for fetching and updating cleanup policy.
Displayed value for retention policy, this is not completely fixed yet.

**Is there anything you'd like reviewers to focus on?**

Before the retention policy was not displayed at all now it is but if you update it, it is not immediately reflected on the page. If you refresh or you go back and forth again it is correct. Maybe someone can point me in a direction what is going wrong here ?

**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (please, describe, if necessary)
- [ ] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [ ] My changes generate no new warnings (e.g. Sonar is happy)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

Check out [Contributing](https://github.com/provectus/kafka-ui/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/provectus/kafka-ui/blob/master/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**
