### PR TITLE
[TRIVIAL]: Enable basic auth for kafka connect cluster

### DIFF
--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/client/KafkaConnectClients.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/client/KafkaConnectClients.java
@@ -1,6 +1,7 @@
 package com.provectus.kafka.ui.client;
 
 import com.provectus.kafka.ui.connect.api.KafkaConnectClientApi;
+import com.provectus.kafka.ui.model.KafkaConnectCluster;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -12,7 +13,7 @@ public final class KafkaConnectClients {
 
   private static final Map<String, KafkaConnectClientApi> CACHE = new ConcurrentHashMap<>();
 
-  public static KafkaConnectClientApi withBaseUrl(String basePath) {
-    return CACHE.computeIfAbsent(basePath, RetryingKafkaConnectClient::new);
+  public static KafkaConnectClientApi withKafkaConnectConfig(KafkaConnectCluster config) {
+    return CACHE.computeIfAbsent(config.getAddress(), s -> new RetryingKafkaConnectClient(config));
   }
 }

--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/client/RetryingKafkaConnectClient.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/client/RetryingKafkaConnectClient.java
@@ -6,6 +6,7 @@ import com.provectus.kafka.ui.connect.model.Connector;
 import com.provectus.kafka.ui.connect.model.NewConnector;
 import com.provectus.kafka.ui.exception.KafkaConnectConflictReponseException;
 import com.provectus.kafka.ui.exception.ValidationException;
+import com.provectus.kafka.ui.model.KafkaConnectCluster;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -26,8 +27,8 @@ public class RetryingKafkaConnectClient extends KafkaConnectClientApi {
   private static final int MAX_RETRIES = 5;
   private static final Duration RETRIES_DELAY = Duration.ofMillis(200);
 
-  public RetryingKafkaConnectClient(String basePath) {
-    super(new RetryingApiClient().setBasePath(basePath));
+  public RetryingKafkaConnectClient(KafkaConnectCluster config) {
+    super(new RetryingApiClient(config));
   }
 
   private static Retry conflictCodeRetry() {
@@ -71,6 +72,14 @@ public class RetryingKafkaConnectClient extends KafkaConnectClientApi {
   }
 
   private static class RetryingApiClient extends ApiClient {
+
+    public RetryingApiClient(KafkaConnectCluster config) {
+      super();
+      setBasePath(config.getAddress());
+      setUsername(config.getUserName());
+      setPassword(config.getPassword());
+    }
+
     @Override
     public <T> Mono<T> invokeAPI(String path, HttpMethod method, Map<String, Object> pathParams,
                                  MultiValueMap<String, String> queryParams, Object body,

--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/config/ClustersProperties.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/config/ClustersProperties.java
@@ -46,6 +46,8 @@ public class ClustersProperties {
   public static class ConnectCluster {
     String name;
     String address;
+    String userName;
+    String password;
   }
 
   @Data

--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/model/KafkaConnectCluster.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/model/KafkaConnectCluster.java
@@ -11,4 +11,6 @@ import lombok.Data;
 public class KafkaConnectCluster {
   private final String name;
   private final String address;
+  private final String userName;
+  private final String password;
 }

--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/serde/schemaregistry/SchemaRegistryAwareRecordSerDe.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/serde/schemaregistry/SchemaRegistryAwareRecordSerDe.java
@@ -141,7 +141,6 @@ public class SchemaRegistryAwareRecordSerDe implements RecordSerDe {
       builder.value(FALLBACK_FORMATTER.format(rec.topic(), rec.value().get()));
       builder.valueFormat(FALLBACK_FORMATTER.getFormat());
     }
-
   }
 
   @Override

--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/service/KafkaConnectService.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/service/KafkaConnectService.java
@@ -326,9 +326,8 @@ public class KafkaConnectService {
   private Mono<KafkaConnectClientApi> withConnectClient(KafkaCluster cluster, String connectName) {
     return Mono.justOrEmpty(cluster.getKafkaConnect().stream()
             .filter(connect -> connect.getName().equals(connectName))
-            .findFirst()
-            .map(KafkaConnectCluster::getAddress))
+            .findFirst())
         .switchIfEmpty(Mono.error(ConnectNotFoundException::new))
-        .map(KafkaConnectClients::withBaseUrl);
+        .map(KafkaConnectClients::withKafkaConnectConfig);
   }
 }

--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/util/ClusterUtil.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/util/ClusterUtil.java
@@ -29,7 +29,6 @@ public class ClusterUtil {
 
   public static TopicMessageDTO mapToTopicMessage(ConsumerRecord<Bytes, Bytes> consumerRecord,
                                                   RecordSerDe recordDeserializer) {
-
     Map<String, String> headers = new HashMap<>();
     consumerRecord.headers().iterator()
         .forEachRemaining(header ->

--- a/kafka-ui-api/src/test/java/com/provectus/kafka/ui/AbstractBaseTest.java
+++ b/kafka-ui-api/src/test/java/com/provectus/kafka/ui/AbstractBaseTest.java
@@ -58,6 +58,8 @@ public abstract class AbstractBaseTest {
       System.setProperty("kafka.clusters.0.bootstrapServers", kafka.getBootstrapServers());
       System.setProperty("kafka.clusters.0.schemaRegistry", schemaRegistry.getUrl());
       System.setProperty("kafka.clusters.0.kafkaConnect.0.name", "kafka-connect");
+      System.setProperty("kafka.clusters.0.kafkaConnect.0.userName", "kafka-connect");
+      System.setProperty("kafka.clusters.0.kafkaConnect.0.password", "kafka-connect");
       System.setProperty("kafka.clusters.0.kafkaConnect.0.address", kafkaConnect.getTarget());
 
       System.setProperty("kafka.clusters.1.name", SECOND_LOCAL);

--- a/kafka-ui-contract/src/main/resources/swagger/kafka-connect-api.yaml
+++ b/kafka-ui-contract/src/main/resources/swagger/kafka-connect-api.yaml
@@ -362,6 +362,10 @@ paths:
                 $ref: '#/components/schemas/ConnectorPluginConfigValidationResponse'
 
 components:
+  securitySchemes:
+    basicAuth:
+      type: http
+      scheme: basic
   schemas:
     ConnectorConfig:
       type: object
@@ -554,4 +558,8 @@ components:
           type: array
           items:
             type: string
+
+
+security:
+  - basicAuth: []
 


### PR DESCRIPTION
**What changes did you make?** (Give an overview)
To enable kafka-ui to connect to kafka-connnect-cluster  which has enabled basic authentication

**Is there anything you'd like reviewers to focus on?**
I have changed the swagger for kafka-connect which adds basic auth 

**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ x] Manually (please, describe, if necessary) Tested by connecting to kafka connect cluster which has basic auth enabled.
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [ x] I have performed a self-review of my own code
- [ x] My changes generate no new warnings (e.g. Sonar is happy)
- [ x] New and existing unit tests pass locally with my changes

Check out [Contributing](https://github.com/provectus/kafka-ui/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/provectus/kafka-ui/blob/master/CODE-OF-CONDUCT.md)


