### PR TITLE
Persist show internal topics switch state

### DIFF
--- a/kafka-ui-react-app/src/components/Topics/List/List.tsx
+++ b/kafka-ui-react-app/src/components/Topics/List/List.tsx
@@ -81,7 +81,9 @@ const List: React.FC<TopicsListProps> = ({
     React.useContext(ClusterContext);
   const { clusterName } = useParams<{ clusterName: ClusterName }>();
   const { page, perPage, pathname } = usePagination();
-  const [showInternal, setShowInternal] = React.useState<boolean>(true);
+  const [showInternal, setShowInternal] = React.useState<boolean>(
+    !localStorage.getItem('hideInternalTopics') && true
+  );
   const [cachedPage, setCachedPage] = React.useState<number | null>(null);
   const history = useHistory();
 
@@ -125,6 +127,12 @@ const List: React.FC<TopicsListProps> = ({
   );
 
   const handleSwitch = React.useCallback(() => {
+    if (showInternal) {
+      localStorage.setItem('hideInternalTopics', 'true');
+    } else {
+      localStorage.removeItem('hideInternalTopics');
+    }
+
     setShowInternal(!showInternal);
     history.push(`${pathname}?page=1&perPage=${perPage || PER_PAGE}`);
   }, [history, pathname, perPage, showInternal]);

--- a/kafka-ui-react-app/src/components/Topics/List/__tests__/List.spec.tsx
+++ b/kafka-ui-react-app/src/components/Topics/List/__tests__/List.spec.tsx
@@ -81,6 +81,7 @@ describe('List', () => {
 
     beforeEach(() => {
       fetchTopicsList = jest.fn();
+
       component = mountComponentWithProviders(
         { isReadOnly: false },
         { fetchTopicsList }
@@ -100,13 +101,28 @@ describe('List', () => {
       expect(setTopicsSearch).toHaveBeenCalledWith(query);
     });
 
+    it('show internal toggle state should match user preference', () => {
+      localStorage.setItem('hideInternalTopics', 'true');
+      component = mountComponentWithProviders(
+        { isReadOnly: false },
+        { fetchTopicsList, totalPages: 10 }
+      );
+
+      const toggle = component.find('input[name="ShowInternalTopics"]');
+      const { checked } = toggle.props();
+
+      expect(checked).toEqual(false);
+    });
+
     it('should refetch topics on show internal toggle change', () => {
       jest.clearAllMocks();
       const toggle = component.find('input[name="ShowInternalTopics"]');
+      const { checked } = toggle.props();
       toggle.simulate('change');
+
       expect(fetchTopicsList).toHaveBeenLastCalledWith({
         search: '',
-        showInternal: false,
+        showInternal: !checked,
         sortOrder: SortOrder.ASC,
       });
     });

--- a/kafka-ui-react-app/src/components/Topics/List/__tests__/List.spec.tsx
+++ b/kafka-ui-react-app/src/components/Topics/List/__tests__/List.spec.tsx
@@ -101,11 +101,18 @@ describe('List', () => {
       expect(setTopicsSearch).toHaveBeenCalledWith(query);
     });
 
+    it('show internal toggle state should be true if user has not used it yet', () => {
+      const toggle = component.find('input[name="ShowInternalTopics"]');
+      const { checked } = toggle.props();
+
+      expect(checked).toEqual(true);
+    });
+
     it('show internal toggle state should match user preference', () => {
       localStorage.setItem('hideInternalTopics', 'true');
       component = mountComponentWithProviders(
         { isReadOnly: false },
-        { fetchTopicsList, totalPages: 10 }
+        { fetchTopicsList }
       );
 
       const toggle = component.find('input[name="ShowInternalTopics"]');

--- a/kafka-ui-react-app/src/components/Topics/List/__tests__/List.spec.tsx
+++ b/kafka-ui-react-app/src/components/Topics/List/__tests__/List.spec.tsx
@@ -76,6 +76,7 @@ describe('List', () => {
   describe('when it does not have readonly flag', () => {
     let fetchTopicsList = jest.fn();
     let component: ReactWrapper;
+    const internalTopicsSwitchName = 'input[name="ShowInternalTopics"]';
 
     jest.useFakeTimers();
 
@@ -102,7 +103,7 @@ describe('List', () => {
     });
 
     it('show internal toggle state should be true if user has not used it yet', () => {
-      const toggle = component.find('input[name="ShowInternalTopics"]');
+      const toggle = component.find(internalTopicsSwitchName);
       const { checked } = toggle.props();
 
       expect(checked).toEqual(true);
@@ -115,7 +116,7 @@ describe('List', () => {
         { fetchTopicsList }
       );
 
-      const toggle = component.find('input[name="ShowInternalTopics"]');
+      const toggle = component.find(internalTopicsSwitchName);
       const { checked } = toggle.props();
 
       expect(checked).toEqual(false);
@@ -123,7 +124,7 @@ describe('List', () => {
 
     it('should refetch topics on show internal toggle change', () => {
       jest.clearAllMocks();
-      const toggle = component.find('input[name="ShowInternalTopics"]');
+      const toggle = component.find(internalTopicsSwitchName);
       const { checked } = toggle.props();
       toggle.simulate('change');
 
@@ -143,7 +144,7 @@ describe('List', () => {
         mockedHistory
       );
 
-      const toggle = component.find('input[name="ShowInternalTopics"]');
+      const toggle = component.find(internalTopicsSwitchName);
       toggle.simulate('change');
 
       expect(mockedHistory.push).toHaveBeenCalledWith('/?page=1&perPage=25');


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)


<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)
Used localstorage to store user's preference of Show Internal Topics switch option and use that preferred value as the initial state.
It would be better to store the localstorage item keys in constants or even have a typed service for localstorage actions with the names that we use in the project. Because the whole project wasn't done that way, I used the existing conventions to implement the feature.

**Is there anything you'd like reviewers to focus on?**

**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (please, describe, if necessary)
- [x] Unit checks
- [x] Integration checks
- [x] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/provectus/kafka-ui/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/provectus/kafka-ui/blob/master/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**
