### PR TITLE
Fix topic messages old data persistence

### DIFF
--- a/kafka-ui-react-app/src/components/Topics/Topic/Topic.tsx
+++ b/kafka-ui-react-app/src/components/Topics/Topic/Topic.tsx
@@ -14,18 +14,26 @@ interface RouterParams {
 
 interface TopicProps {
   isTopicFetching: boolean;
+  resetTopicMessages: () => void;
   fetchTopicDetails: (clusterName: ClusterName, topicName: TopicName) => void;
 }
 
 const Topic: React.FC<TopicProps> = ({
   isTopicFetching,
   fetchTopicDetails,
+  resetTopicMessages,
 }) => {
   const { clusterName, topicName } = useParams<RouterParams>();
 
   React.useEffect(() => {
     fetchTopicDetails(clusterName, topicName);
   }, [fetchTopicDetails, clusterName, topicName]);
+
+  React.useEffect(() => {
+    return () => {
+      resetTopicMessages();
+    };
+  }, []);
 
   if (isTopicFetching) {
     return <PageLoader />;

--- a/kafka-ui-react-app/src/components/Topics/Topic/TopicContainer.tsx
+++ b/kafka-ui-react-app/src/components/Topics/Topic/TopicContainer.tsx
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import { RootState } from 'redux/interfaces';
-import { fetchTopicDetails } from 'redux/actions';
+import { fetchTopicDetails, resetTopicMessages } from 'redux/actions';
 import { getIsTopicDetailsFetching } from 'redux/reducers/topics/selectors';
 
 import Topic from './Topic';
@@ -11,6 +11,7 @@ const mapStateToProps = (state: RootState) => ({
 
 const mapDispatchToProps = {
   fetchTopicDetails,
+  resetTopicMessages,
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(Topic);

--- a/kafka-ui-react-app/src/components/Topics/Topic/__tests__/Topic.spec.tsx
+++ b/kafka-ui-react-app/src/components/Topics/Topic/__tests__/Topic.spec.tsx
@@ -22,6 +22,7 @@ jest.mock('components/common/PageLoader/PageLoader', () => () => (
   <div>Loading</div>
 ));
 
+const resetTopicMessages = jest.fn();
 const fetchTopicDetailsMock = jest.fn();
 
 const renderComponent = (pathname: string, topicFetching: boolean) =>
@@ -29,6 +30,7 @@ const renderComponent = (pathname: string, topicFetching: boolean) =>
     <Route path={clusterTopicPath(':clusterName', ':topicName')}>
       <Topic
         isTopicFetching={topicFetching}
+        resetTopicMessages={resetTopicMessages}
         fetchTopicDetails={fetchTopicDetailsMock}
       />
     </Route>,
@@ -58,4 +60,13 @@ it('renders Page loader', () => {
 it('fetches topicDetails', () => {
   renderComponent(clusterTopicPath('local', 'myTopicName'), false);
   expect(fetchTopicDetailsMock).toHaveBeenCalledTimes(1);
+});
+
+it('resets topic messages after unmount', () => {
+  const component = renderComponent(
+    clusterTopicPath('local', 'myTopicName'),
+    false
+  );
+  component.unmount();
+  expect(resetTopicMessages).toHaveBeenCalledTimes(1);
 });


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)


<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)
Added a cleanup to reset topic messages when the Topic component is unmounted to prevent displaying old data.

**Is there anything you'd like reviewers to focus on?**


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (please, describe, if necessary)
- [x] Unit checks
- [ ] Integration checks
- [x] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/provectus/kafka-ui/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/provectus/kafka-ui/blob/master/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**
