### PR TITLE
adding clear message if connector with new name already exists

### DIFF
--- a/kafka-ui-react-app/src/redux/actions/__test__/thunks/connectors.spec.ts
+++ b/kafka-ui-react-app/src/redux/actions/__test__/thunks/connectors.spec.ts
@@ -192,7 +192,7 @@ describe('Thunks', () => {
         actions.createConnectorAction.failure({
           alert: {
             subject: 'local-first',
-            title: 'Kafka Connect Connector Create',
+            title: `Connector with name ${connectorName} already exists`,
             response: {
               status: 404,
               statusText: 'Not Found',

--- a/kafka-ui-react-app/src/redux/actions/thunks/connectors.ts
+++ b/kafka-ui-react-app/src/redux/actions/thunks/connectors.ts
@@ -111,7 +111,7 @@ export const createConnector =
       const response = await getResponse(error);
       const alert: FailurePayload = {
         subject: [clusterName, connectName].join('-'),
-        title: `Kafka Connect Connector Create`,
+        title: `Connector with name ${newConnector.name} already exists`,
         response,
       };
       dispatch(actions.createConnectorAction.failure({ alert }));


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)


<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)

Changed error message when Connector with that name already exists and added the same in tests

**Is there anything you'd like reviewers to focus on?**

**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (please, describe, if necessary)
- [x] Unit checks
- [x] Integration checks
- [x] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/provectus/kafka-ui/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/provectus/kafka-ui/blob/master/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**
<img width="579" alt="Screen Shot 2022-04-15 at 18 32 14" src="https://user-images.githubusercontent.com/103438454/163583442-2ce478e4-2ee1-4bbe-aec7-fa172a714616.png">
