### PR TITLE
Show confirmation modal when clear messages is clicked in topics list

### DIFF
--- a/kafka-ui-react-app/src/components/Topics/List/List.tsx
+++ b/kafka-ui-react-app/src/components/Topics/List/List.tsx
@@ -86,7 +86,7 @@ const List: React.FC<TopicsListProps> = ({
   const [cachedPage, setCachedPage] = React.useState<number | null>(null);
   const history = useHistory();
 
-  const fetchTopicsListParams = React.useMemo(
+  const topicsListParams = React.useMemo(
     () => ({
       clusterName,
       page,
@@ -100,8 +100,8 @@ const List: React.FC<TopicsListProps> = ({
   );
 
   React.useEffect(() => {
-    fetchTopicsList(fetchTopicsListParams);
-  }, [fetchTopicsList, fetchTopicsListParams]);
+    fetchTopicsList(topicsListParams);
+  }, [fetchTopicsList, topicsListParams]);
 
   const tableState = useTableState<
     TopicWithDetailedInfo,
@@ -209,7 +209,7 @@ const List: React.FC<TopicsListProps> = ({
 
       const clearTopicMessagesHandler = React.useCallback(() => {
         clearTopicMessages(clusterName, name);
-        fetchTopicsList(fetchTopicsListParams);
+        fetchTopicsList(topicsListParams);
         setClearMessagesConfirmationVisible(false);
       }, [name]);
 

--- a/kafka-ui-react-app/src/components/Topics/List/List.tsx
+++ b/kafka-ui-react-app/src/components/Topics/List/List.tsx
@@ -8,6 +8,7 @@ import {
 import { useParams } from 'react-router-dom';
 import { clusterTopicCopyPath, clusterTopicNewPath } from 'lib/paths';
 import usePagination from 'lib/hooks/usePagination';
+import useModal from 'lib/hooks/useModal';
 import ClusterContext from 'components/contexts/ClusterContext';
 import PageLoader from 'components/common/PageLoader/PageLoader';
 import ConfirmationModal from 'components/common/ConfirmationModal/ConfirmationModal';
@@ -186,20 +187,23 @@ const List: React.FC<TopicsListProps> = ({
 
   const ActionsCell = React.memo<TableCellProps<TopicWithDetailedInfo, string>>(
     ({ hovered, dataItem: { internal, cleanUpPolicy, name } }) => {
-      const [
-        isDeleteTopicConfirmationVisible,
-        setDeleteTopicConfirmationVisible,
-      ] = React.useState(false);
+      const {
+        isOpen: isDeleteTopicModalOpen,
+        setClose: closeDeleteTopicModal,
+        setOpen: openDeleteTopicModal,
+      } = useModal(false);
 
-      const [
-        isRecreateTopicConfirmationVisible,
-        setRecreateTopicConfirmationVisible,
-      ] = React.useState(false);
+      const {
+        isOpen: isRecreateTopicModalOpen,
+        setClose: closeRecreateTopicModal,
+        setOpen: openRecreateTopicModal,
+      } = useModal(false);
 
-      const [
-        isClearMessagesConfirmationVisible,
-        setClearMessagesConfirmationVisible,
-      ] = React.useState(false);
+      const {
+        isOpen: isClearMessagesModalOpen,
+        setClose: closeClearMessagesModal,
+        setOpen: openClearMessagesModal,
+      } = useModal(false);
 
       const isHidden = internal || isReadOnly || !hovered;
 
@@ -210,12 +214,12 @@ const List: React.FC<TopicsListProps> = ({
       const clearTopicMessagesHandler = React.useCallback(() => {
         clearTopicMessages(clusterName, name);
         fetchTopicsList(topicsListParams);
-        setClearMessagesConfirmationVisible(false);
+        closeClearMessagesModal();
       }, [name, fetchTopicsList, topicsListParams]);
 
       const recreateTopicHandler = React.useCallback(() => {
         recreateTopic(clusterName, name);
-        setRecreateTopicConfirmationVisible(false);
+        closeRecreateTopicModal();
       }, [name]);
 
       return (
@@ -224,47 +228,38 @@ const List: React.FC<TopicsListProps> = ({
             {!isHidden && (
               <Dropdown label={<VerticalElipsisIcon />} right>
                 {cleanUpPolicy === CleanUpPolicy.DELETE && (
-                  <DropdownItem
-                    onClick={() => setClearMessagesConfirmationVisible(true)}
-                    danger
-                  >
+                  <DropdownItem onClick={openClearMessagesModal} danger>
                     Clear Messages
                   </DropdownItem>
                 )}
                 {isTopicDeletionAllowed && (
-                  <DropdownItem
-                    onClick={() => setDeleteTopicConfirmationVisible(true)}
-                    danger
-                  >
+                  <DropdownItem onClick={openDeleteTopicModal} danger>
                     Remove Topic
                   </DropdownItem>
                 )}
-                <DropdownItem
-                  onClick={() => setRecreateTopicConfirmationVisible(true)}
-                  danger
-                >
+                <DropdownItem onClick={openRecreateTopicModal} danger>
                   Recreate Topic
                 </DropdownItem>
               </Dropdown>
             )}
           </div>
           <ConfirmationModal
-            isOpen={isClearMessagesConfirmationVisible}
-            onCancel={() => setClearMessagesConfirmationVisible(false)}
+            isOpen={isClearMessagesModalOpen}
+            onCancel={closeClearMessagesModal}
             onConfirm={clearTopicMessagesHandler}
           >
             Are you sure want to clear topic messages?
           </ConfirmationModal>
           <ConfirmationModal
-            isOpen={isDeleteTopicConfirmationVisible}
-            onCancel={() => setDeleteTopicConfirmationVisible(false)}
+            isOpen={isDeleteTopicModalOpen}
+            onCancel={closeDeleteTopicModal}
             onConfirm={deleteTopicHandler}
           >
             Are you sure want to remove <b>{name}</b> topic?
           </ConfirmationModal>
           <ConfirmationModal
-            isOpen={isRecreateTopicConfirmationVisible}
-            onCancel={() => setRecreateTopicConfirmationVisible(false)}
+            isOpen={isRecreateTopicModalOpen}
+            onCancel={closeRecreateTopicModal}
             onConfirm={recreateTopicHandler}
           >
             Are you sure to recreate <b>{name}</b> topic?

--- a/kafka-ui-react-app/src/components/Topics/List/List.tsx
+++ b/kafka-ui-react-app/src/components/Topics/List/List.tsx
@@ -211,7 +211,7 @@ const List: React.FC<TopicsListProps> = ({
         clearTopicMessages(clusterName, name);
         fetchTopicsList(topicsListParams);
         setClearMessagesConfirmationVisible(false);
-      }, [name]);
+      }, [name, fetchTopicsList, topicsListParams]);
 
       const recreateTopicHandler = React.useCallback(() => {
         recreateTopic(clusterName, name);


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)


<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)
Open confirmation modal when clear messages is clicked and refetch to update data.

**Is there anything you'd like reviewers to focus on?**


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (please, describe, if necessary)
- [ ] Unit checks
- [ ] Integration checks
- [x] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/provectus/kafka-ui/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/provectus/kafka-ui/blob/master/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**
