### PR TITLE
Fix seek type select styles

### DIFF
--- a/kafka-ui-react-app/src/components/Topics/Topic/Details/Messages/Filters/Filters.styled.ts
+++ b/kafka-ui-react-app/src/components/Topics/Topic/Details/Messages/Filters/Filters.styled.ts
@@ -1,3 +1,4 @@
+import Select from 'components/common/Select/Select';
 import styled, { css } from 'styled-components';
 
 interface SavedFilterProps {
@@ -312,4 +313,10 @@ export const SavedFiltersText = styled.div`
 export const BackToCustomText = styled.div`
   ${textStyle};
   cursor: pointer;
+`;
+
+export const SeekTypeSelect = styled(Select)`
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+  user-select: none;
 `;

--- a/kafka-ui-react-app/src/components/Topics/Topic/Details/Messages/Filters/Filters.tsx
+++ b/kafka-ui-react-app/src/components/Topics/Topic/Details/Messages/Filters/Filters.tsx
@@ -355,7 +355,7 @@ const Filters: React.FC<FiltersProps> = ({
             handleSearch={(value: string) => setQuery(value)}
           />
           <S.SeekTypeSelectorWrapper>
-            <Select
+            <S.SeekTypeSelect
               id="selectSeekType"
               onChange={(option) => setCurrentSeekType(option as SeekType)}
               value={currentSeekType}


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)


<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)
Fixed border-radius style of the seek type select component in Topic Messages Filters component 

**Is there anything you'd like reviewers to focus on?**


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (please, describe, if necessary)
- [ ] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/provectus/kafka-ui/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/provectus/kafka-ui/blob/master/CODE-OF-CONDUCT.md)

**Result**
<img width="288" alt="image" src="https://user-images.githubusercontent.com/103444767/165459027-43d766e6-3e19-4ec7-89fa-a009045392e4.png">
