### PR TITLE
Fixing connector't tasks count update is not available without refreshing

### DIFF
--- a/kafka-ui-react-app/src/redux/reducers/connect/__test__/reducer.spec.ts
+++ b/kafka-ui-react-app/src/redux/reducers/connect/__test__/reducer.spec.ts
@@ -726,6 +726,7 @@ describe('Connect slice', () => {
           );
           expect(getTypeAndPayload(store)).toEqual([
             { type: updateConnectorConfig.pending.type, payload: undefined },
+            { type: fetchConnector.pending.type },
             ...getAlertActions(store),
             {
               type: updateConnectorConfig.fulfilled.type,

--- a/kafka-ui-react-app/src/redux/reducers/connect/connectSlice.ts
+++ b/kafka-ui-react-app/src/redux/reducers/connect/connectSlice.ts
@@ -322,7 +322,7 @@ export const updateConnectorConfig = createAsyncThunk<
         connectorName,
         requestBody: connectorConfig,
       });
-
+      dispatch(fetchConnector({ clusterName, connectName, connectorName }));
       dispatch(
         showSuccessAlert({
           id: `connector-${connectorName}-${clusterName}`,


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)


<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)

**Is there anything you'd like reviewers to focus on?**


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (please, describe, if necessary)
- [x] Unit checks
- [x] Integration checks
- [x] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/provectus/kafka-ui/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/provectus/kafka-ui/blob/master/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**
