### PR TITLE
Use DD.MM.YYYY date format

### DIFF
--- a/kafka-ui-react-app/src/components/Topics/Topic/Details/Messages/Message.tsx
+++ b/kafka-ui-react-app/src/components/Topics/Topic/Details/Messages/Message.tsx
@@ -66,7 +66,7 @@ const Message: React.FC<Props> = ({
         <td>{offset}</td>
         <td>{partition}</td>
         <td>
-          <div>{dayjs(timestamp).format('MM.DD.YYYY HH:mm:ss')}</div>
+          <div>{dayjs(timestamp).format('DD.MM.YYYY HH:mm:ss')}</div>
         </td>
         <StyledDataCell title={key}>{key}</StyledDataCell>
         <StyledDataCell>

--- a/kafka-ui-react-app/src/components/Topics/Topic/Details/Messages/MessageContent/MessageContent.tsx
+++ b/kafka-ui-react-app/src/components/Topics/Topic/Details/Messages/MessageContent/MessageContent.tsx
@@ -95,7 +95,7 @@ const MessageContent: React.FC<MessageContentProps> = ({
               <S.MetadataLabel>Timestamp</S.MetadataLabel>
               <span>
                 <S.MetadataValue>
-                  {dayjs(timestamp).format('MM.DD.YYYY HH:mm:ss')}
+                  {dayjs(timestamp).format('DD.MM.YYYY HH:mm:ss')}
                 </S.MetadataValue>
                 <S.MetadataMeta>Timestamp type: {timestampType}</S.MetadataMeta>
               </span>

--- a/kafka-ui-react-app/src/components/Topics/Topic/Details/Messages/__test__/Message.spec.tsx
+++ b/kafka-ui-react-app/src/components/Topics/Topic/Details/Messages/__test__/Message.spec.tsx
@@ -51,7 +51,7 @@ describe('Message component', () => {
     expect(screen.getByText(mockMessage.key as string)).toBeInTheDocument();
     expect(
       screen.getByText(
-        dayjs(mockMessage.timestamp).format('MM.DD.YYYY HH:mm:ss')
+        dayjs(mockMessage.timestamp).format('DD.MM.YYYY HH:mm:ss')
       )
     ).toBeInTheDocument();
     expect(screen.getByText(mockMessage.offset.toString())).toBeInTheDocument();


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)


<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)
Change date format to `DD.MM.YYYY` which will cover more population than previous format and is is less confusing than  `MM.DD.YYYY`

Issue: https://github.com/provectus/kafka-ui/issues/2162

**Is there anything you'd like reviewers to focus on?**


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (please, describe, if necessary)
- [x] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/provectus/kafka-ui/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/provectus/kafka-ui/blob/master/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**
![зображення](https://user-images.githubusercontent.com/7952949/178037078-d54569b2-d28a-4e93-aaad-826fa452b72b.png)
