### PR TITLE
Publish and delete docker image in public ecr

### DIFF
--- a/.github/workflows/build-public-image.yml
+++ b/.github/workflows/build-public-image.yml
@@ -1,0 +1,78 @@
+name: Build Docker image and push
+on:
+  workflow_dispatch:
+  pull_request:
+    types: ['labeled']
+jobs:
+  build:
+    if: ${{ github.event.label.name == 'status/image_testing' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: get branch name
+        id: extract_branch
+        run: |
+          tag='${{ github.event.pull_request.number }}'
+          echo ::set-output name=tag::${tag}
+      - name: Cache local Maven repository
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Set up JDK 1.13
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.13
+      - name: Build
+        id: build
+        run: |
+          mvn versions:set -DnewVersion=$GITHUB_SHA
+          mvn clean package -Pprod -DskipTests
+          export VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
+          echo "::set-output name=version::${VERSION}"
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - name: Configure AWS credentials for Kafka-UI account
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+        with:
+          registry-type: 'public'
+      - name: Build and push
+        id: docker_build_and_push
+        uses: docker/build-push-action@v2
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: kafka-ui-api
+          push: true
+          tags: public.ecr.aws/provectus/kafka-ui-custom-build:${{ steps.extract_branch.outputs.tag }}
+          build-args: |
+            JAR_FILE=kafka-ui-api-${{ steps.build.outputs.version }}.jar
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+      - name: make comment with private deployment link
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            Image published at public.ecr.aws/provectus/kafka-ui-custom-build:${{ steps.extract_branch.outputs.tag }}
+
+    outputs:
+      tag: ${{ steps.extract_branch.outputs.tag }}

--- a/.github/workflows/delete-public-image.yml
+++ b/.github/workflows/delete-public-image.yml
@@ -1,0 +1,40 @@
+name: Delete Public ECR Image
+on:
+  workflow_dispatch:
+  pull_request:
+    types: ['unlabeled', 'closed']
+jobs:
+  remove:
+    if: |
+      ${{ github.event.label.name == 'status/image_testing' || ( github.event.action == 'closed' && (contains(github.event.pull_request.labels, 'status/image_testing'))) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: get branch name
+        id: extract_branch
+        run: |
+          tag='${{ github.event.pull_request.number }}'
+          echo ::set-output name=tag::${tag}
+      - name: Configure AWS credentials for Kafka-UI account
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+        with:
+          registry-type: 'public'
+      - name: Remove from ECR
+        id: remove_from_ecr
+        run: |
+          aws ecr-public batch-delete-image \
+                --repository-name kafka-ui-custom-build \
+                --image-ids imageTag=${{ steps.extract_branch.outputs.tag }} \
+                --region us-east-1
+      - name: make comment with private deployment link
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            Image tag public.ecr.aws/provectus/kafka-ui-custom-build:${{ steps.extract_branch.outputs.tag }} has been removed

--- a/.github/workflows/delete-public-image.yml
+++ b/.github/workflows/delete-public-image.yml
@@ -5,13 +5,13 @@ on:
     types: ['unlabeled', 'closed']
 jobs:
   remove:
-    if: |
-      ${{ github.event.label.name == 'status/image_testing' || ( github.event.action == 'closed' && (contains(github.event.pull_request.labels, 'status/image_testing'))) }}
+    if: ${{ github.event.label.name == 'status/image_testing' || ( github.event.action == 'closed' && (contains(github.event.pull_request.labels, 'status/image_testing'))) }}
     runs-on: ubuntu-latest
     steps:
       - name: get branch name
         id: extract_branch
         run: |
+          echo
           tag='${{ github.event.pull_request.number }}'
           echo ::set-output name=tag::${tag}
       - name: Configure AWS credentials for Kafka-UI account


### PR DESCRIPTION
This PR adds two GitHub workflows:

1. Build and push docker image into public ecr repo by adding tag 'status/image_testing'. Add a comment to the PR with the name of Image Repo.
2. Remove image tag by removing tag or close PR with existing 'status/image_testing' tag. Add comment to the PR that the existing Image tag was removed from Image Repo.

This PR cover [issue](https://github.com/provectus/kafka-ui/issues/2212) 
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (please, describe, if necessary)
- [ ] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

<!-- ignore-task-list-start -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged
<!-- ignore-task-list-end -->
