### PR TITLE
Add HealthCheck wait for KafkaConnect (#2449)

### DIFF
--- a/kafka-ui-api/src/test/java/com/provectus/kafka/ui/container/KafkaConnectContainer.java
+++ b/kafka-ui-api/src/test/java/com/provectus/kafka/ui/container/KafkaConnectContainer.java
@@ -1,6 +1,5 @@
 package com.provectus.kafka.ui.container;
 
-import java.time.Duration;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.containers.Network;
@@ -12,8 +11,7 @@ public class KafkaConnectContainer extends GenericContainer<KafkaConnectContaine
   public KafkaConnectContainer(String version) {
     super("confluentinc/cp-kafka-connect:" + version);
     addExposedPort(CONNECT_PORT);
-    waitStrategy = Wait.forHttp("/")
-        .withStartupTimeout(Duration.ofMinutes(5));
+    Wait.forHealthcheck();
   }
 
 

--- a/kafka-ui-api/src/test/java/com/provectus/kafka/ui/container/SchemaRegistryContainer.java
+++ b/kafka-ui-api/src/test/java/com/provectus/kafka/ui/container/SchemaRegistryContainer.java
@@ -11,7 +11,7 @@ public class SchemaRegistryContainer extends GenericContainer<SchemaRegistryCont
 
   public SchemaRegistryContainer(String version) {
     super("confluentinc/cp-schema-registry:" + version);
-    withExposedPorts(8081);
+    withExposedPorts(SCHEMA_PORT);
   }
 
   public SchemaRegistryContainer withKafka(KafkaContainer kafka) {


### PR DESCRIPTION
* Remove hardcoded port for Schema Registry
* closes #2449 

<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)


<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)
I have updated the Wait strategy of Kafka Connect container from path based to healthchecks based.
Also removed an hardcoded port used in Schema registry container constructor call.

**Is there anything you'd like reviewers to focus on?**


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (please, describe, if necessary)
- [ ] Unit checks
- [ ] Integration checks
- [x] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [ ] My changes generate no new warnings (e.g. Sonar is happy)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

Check out [Contributing](https://github.com/provectus/kafka-ui/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/provectus/kafka-ui/blob/master/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**
