### PR TITLE
Fix #2393

### DIFF
--- a/charts/kafka-ui/templates/secret.yaml
+++ b/charts/kafka-ui/templates/secret.yaml
@@ -6,4 +6,6 @@ metadata:
     {{- include "kafka-ui.labels" . | nindent 4 }}
 type: Opaque
 data:
-  {{- toYaml .Values.envs.secret | nindent 2 }}
+  {{- range $key, $val := .Values.envs.secret }}
+  {{ $key }}: {{ $val | b64enc | quote }}
+  {{- end -}}


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [X] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)

On Helm Chart installations, any values of .envs.secret should not be encoded in b64 as such, any existing value should be decoded.

<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)
On the helm-chart the values on envs.secret needed to be in base64, instead we can encode it on template rendering streamlining the process and helping with readability of the configuration files.

**Is there anything you'd like reviewers to focus on?**
No.


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (please, describe, if necessary)
- [ ] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/provectus/kafka-ui/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/provectus/kafka-ui/blob/master/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**
