### PR TITLE
Prevent negative values in Go to Page Field In Pagination

### DIFF
--- a/kafka-ui-react-app/src/components/common/NewTable/Table.tsx
+++ b/kafka-ui-react-app/src/components/common/NewTable/Table.tsx
@@ -190,6 +190,25 @@ const Table: React.FC<TableProps<any>> = ({
     return undefined;
   };
 
+  // Prevent Users to paste negative values in go to page field
+  const preventPasteNegative = (event: React.ClipboardEvent) => {
+    const { clipboardData } = event;
+    if (clipboardData != null) {
+      const pastedData = parseFloat(clipboardData.getData('text'));
+
+      if (pastedData < 0) {
+        event.preventDefault();
+      }
+    }
+  };
+
+  // Prevent Users to type negative values in go to page field
+  const preventMinus = (event: React.KeyboardEvent) => {
+    if (event.code === 'Minus') {
+      event.preventDefault();
+    }
+  };
+
   return (
     <>
       {table.getSelectedRowModel().flatRows.length > 0 && Bar && (
@@ -333,6 +352,8 @@ const Table: React.FC<TableProps<any>> = ({
                 inputSize="M"
                 max={table.getPageCount()}
                 min={1}
+                onKeyPress={preventMinus}
+                onPaste={preventPasteNegative}
                 onChange={({ target: { value } }) => {
                   const index = value ? Number(value) - 1 : 0;
                   table.setPageIndex(index);


### PR DESCRIPTION
Closes #2451

<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)


<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)
We shouldn't make `Go to page` uneditable because idea behind `Go to Page` is users can jump on to any pages directly. @armenuikafka 

Now about setting invalid values, I have added two functions to ensure user can't input negative values and also can't paste negative values into `Go to Page` field.

**Is there anything you'd like reviewers to focus on?**


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (please, describe, if necessary)
- [ ] Unit checks
- [ ] Integration checks
- [x] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/provectus/kafka-ui/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/provectus/kafka-ui/blob/master/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**
