### PR TITLE
Make topic bulk actions buttons always visible

### DIFF
--- a/kafka-ui-react-app/src/components/Topics/List/BatchActionsBar.tsx
+++ b/kafka-ui-react-app/src/components/Topics/List/BatchActionsBar.tsx
@@ -63,6 +63,12 @@ const BatchActionsbar: React.FC<BatchActionsbarProps> = ({
   type Tuple = [string, string];
 
   const getCopyTopicPath = () => {
+    if (!rows.length) {
+      return {
+        pathname: '',
+        search: '',
+      };
+    }
     const topic = rows[0].original;
 
     const search = Object.keys(topic).reduce((acc: Tuple[], key) => {
@@ -86,13 +92,14 @@ const BatchActionsbar: React.FC<BatchActionsbarProps> = ({
         buttonSize="M"
         buttonType="secondary"
         onClick={deleteTopicsHandler}
+        disabled={!selectedTopics.length}
       >
         Delete selected topics
       </Button>
       <Button
         buttonSize="M"
         buttonType="secondary"
-        disabled={selectedTopics.length > 1}
+        disabled={selectedTopics.length !== 1}
         to={getCopyTopicPath()}
       >
         Copy selected topic
@@ -101,6 +108,7 @@ const BatchActionsbar: React.FC<BatchActionsbarProps> = ({
         buttonSize="M"
         buttonType="secondary"
         onClick={purgeTopicsHandler}
+        disabled={!selectedTopics.length}
       >
         Purge messages of selected topics
       </Button>

--- a/kafka-ui-react-app/src/components/common/NewTable/Table.tsx
+++ b/kafka-ui-react-app/src/components/common/NewTable/Table.tsx
@@ -101,7 +101,7 @@ const getSortingFromSearchParams = (searchParams: URLSearchParams) => {
  *    - use `enableRowSelection` prop to enable row selection. This prop can be a boolean or
  *      a function that returns true if the particular row can be selected.
  *    - use `batchActionsBar` prop to provide a component that will be rendered at the top of the table
- *      when row selection is enabled and there are selected rows.
+ *      when row selection is enabled.
  *
  * 5. Server side processing:
  *    - set `serverSideProcessing` to true
@@ -190,7 +190,7 @@ const Table: React.FC<TableProps<any>> = ({
 
   return (
     <>
-      {table.getSelectedRowModel().flatRows.length > 0 && BatchActionsBar && (
+      {BatchActionsBar && (
         <S.TableActionsBar>
           <BatchActionsBar
             rows={table.getSelectedRowModel().flatRows}

--- a/kafka-ui-react-app/src/components/common/NewTable/__test__/Table.spec.tsx
+++ b/kafka-ui-react-app/src/components/common/NewTable/__test__/Table.spec.tsx
@@ -318,7 +318,7 @@ describe('Table', () => {
 
     it('renders action bar', async () => {
       expect(screen.getAllByRole('row').length).toEqual(data.length + 1);
-      expect(screen.queryByText('I am Action Bar')).not.toBeInTheDocument();
+      expect(screen.queryByText('I am Action Bar')).toBeInTheDocument();
       const checkboxes = screen.getAllByRole('checkbox');
       expect(checkboxes.length).toEqual(data.length + 1);
       await userEvent.click(checkboxes[2]);


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [x] **Breaking change?** No

<!-- ignore-task-list-end -->
**What changes did you make?** BatchActionsBar is always visible from now on but buttons would be disabled in such case

**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (please, describe, if necessary)
- [ ] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/provectus/kafka-ui/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/provectus/kafka-ui/blob/master/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**
