### PR TITLE
Tests: Fix `NullPointerException` in `QaseExtension` if token is unavailable

### DIFF
--- a/kafka-ui-e2e-checks/src/main/java/com/provectus/kafka/ui/utilities/qaseIoUtils/QaseExtension.java
+++ b/kafka-ui-e2e-checks/src/main/java/com/provectus/kafka/ui/utilities/qaseIoUtils/QaseExtension.java
@@ -39,7 +39,8 @@ public class QaseExtension implements TestExecutionListener {
     static {
         String qaseApiToken = System.getProperty("QASEIO_API_TOKEN");
         if (StringUtils.isEmpty(qaseApiToken)) {
-           System.setProperty("QASE_ENABLE", "false");
+            log.warn("QASEIO_API_TOKEN system property is not set. Support for Qase will be disabled.");
+            System.setProperty("QASE_ENABLE", "false");
         } else {
             System.setProperty("QASE_ENABLE", "true");
             System.setProperty("QASE_PROJECT_CODE", QASE_PROJECT);

--- a/kafka-ui-e2e-checks/src/main/java/com/provectus/kafka/ui/utilities/qaseIoUtils/QaseExtension.java
+++ b/kafka-ui-e2e-checks/src/main/java/com/provectus/kafka/ui/utilities/qaseIoUtils/QaseExtension.java
@@ -35,21 +35,21 @@ public class QaseExtension implements TestExecutionListener {
     private final ResultsApi resultsApi = new ResultsApi(apiClient);
     private final Map<TestIdentifier, Long> testStartTimes = new ConcurrentHashMap<>();
     private static final String QASE_PROJECT = "KAFKAUI";
-    private static final String QASE_ENABLE = "true";
 
     static {
         String qaseApiToken = System.getProperty("QASEIO_API_TOKEN");
-        if (qaseApiToken == null || StringUtils.isEmpty(qaseApiToken)) {
-            throw new RuntimeException("QaseIO API token should be present");
+        if (StringUtils.isEmpty(qaseApiToken)) {
+           System.setProperty("QASE_ENABLE", "false");
+        } else {
+            System.setProperty("QASE_ENABLE", "true");
+            System.setProperty("QASE_PROJECT_CODE", QASE_PROJECT);
+            System.setProperty("QASE_API_TOKEN", qaseApiToken);
+            System.setProperty("QASE_USE_BULK", "false");
+            if ("true".equalsIgnoreCase(System.getProperty("QASEIO_CREATE_TESTRUN"))) {
+              System.setProperty("QASE_RUN_NAME", "Automation run " +
+                   new SimpleDateFormat("dd/MM/yyyy HH:mm:ss").format(new Date()));
+            }
         }
-        if ("true".equalsIgnoreCase(System.getProperty("QASEIO_CREATE_TESTRUN"))) {
-            System.setProperty("QASE_RUN_NAME", "Automation run " +
-                    new SimpleDateFormat("dd/MM/yyyy HH:mm:ss").format(new Date()));
-        }
-        System.setProperty("QASE_ENABLE", QASE_ENABLE);
-        System.setProperty("QASE_PROJECT_CODE", QASE_PROJECT);
-        System.setProperty("QASE_API_TOKEN", qaseApiToken);
-        System.setProperty("QASE_USE_BULK", "false");
     }
 
     @Override


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)


<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)

The `QaseExtension` JUnit extension fails with a `NullPointerException` if `QASE_API_TOKEN` is unset.

Ideally, the extension would skip execution if the token was unavailable instead of failing.

<details>
<summary>Stack trace</summary>

```
org.apache.maven.surefire.util.SurefireReflectionException: java.util.ServiceConfigurationError: org.junit.platform.launcher.TestExecutionListener: Provider com.provectus.kafka.ui.utilities.qaseIoUtils.QaseExtension could not be instantiated
        at org.apache.maven.surefire.util.ReflectionUtils.instantiateOneArg(ReflectionUtils.java:139)
        at org.apache.maven.surefire.booter.ForkedBooter.createProviderInCurrentClassloader(ForkedBooter.java:403)
        at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:383)
        at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:345)
        at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:126)
        at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:418)
Caused by: java.util.ServiceConfigurationError: org.junit.platform.launcher.TestExecutionListener: Provider com.provectus.kafka.ui.utilities.qaseIoUtils.QaseExtension could not be instantiated
        at java.base/java.util.ServiceLoader.fail(ServiceLoader.java:586)
        at java.base/java.util.ServiceLoader$ProviderImpl.newInstance(ServiceLoader.java:813)
        at java.base/java.util.ServiceLoader$ProviderImpl.get(ServiceLoader.java:729)
        at java.base/java.util.ServiceLoader$3.next(ServiceLoader.java:1403)
        at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133)
        at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1921)
        at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
        at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
        at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
        at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
        at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
        at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:596)
        at org.junit.platform.launcher.core.LauncherFactory.registerTestExecutionListeners(LauncherFactory.java:179)
        at org.junit.platform.launcher.core.LauncherFactory.createDefaultLauncher(LauncherFactory.java:137)
        at org.junit.platform.launcher.core.LauncherFactory.create(LauncherFactory.java:125)
        at org.junit.platform.launcher.core.LauncherFactory.create(LauncherFactory.java:109)
        at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.<init>(JUnitPlatformProvider.java:86)
        at java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:67)
        at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:500)
        at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:484)
        at org.apache.maven.surefire.util.ReflectionUtils.instantiateOneArg(ReflectionUtils.java:135)
        ... 5 more
Caused by: java.lang.ExceptionInInitializerError
        at java.base/jdk.internal.misc.Unsafe.ensureClassInitialized0(Native Method)
        at java.base/jdk.internal.misc.Unsafe.ensureClassInitialized(Unsafe.java:1160)
        at java.base/jdk.internal.reflect.MethodHandleAccessorFactory.ensureClassInitialized(MethodHandleAccessorFactory.java:300)
        at java.base/jdk.internal.reflect.MethodHandleAccessorFactory.newConstructorAccessor(MethodHandleAccessorFactory.java:103)
        at java.base/jdk.internal.reflect.ReflectionFactory.newConstructorAccessor(ReflectionFactory.java:201)
        at java.base/java.lang.reflect.Constructor.acquireConstructorAccessor(Constructor.java:547)
        at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:497)
        at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:484)
        at java.base/java.util.ServiceLoader$ProviderImpl.newInstance(ServiceLoader.java:789)
        ... 24 more
Caused by: java.lang.NullPointerException
        at java.base/java.util.concurrent.ConcurrentHashMap.putVal(ConcurrentHashMap.java:1011)
        at java.base/java.util.concurrent.ConcurrentHashMap.put(ConcurrentHashMap.java:1006)
        at java.base/java.util.Properties.put(Properties.java:1340)
        at java.base/java.util.Properties.setProperty(Properties.java:230)
        at java.base/java.lang.System.setProperty(System.java:1043)
        at com.provectus.kafka.ui.utilities.qaseIoUtils.QaseExtension.<clinit>(QaseExtension.java:51)
        ... 33 more
```
</details>

**Is there anything you'd like reviewers to focus on?**


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [x] No need to
- [x] Manually (please, describe, if necessary)
- [ ] Unit checks
- [ ] Integration checks
- [x] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/provectus/kafka-ui/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/provectus/kafka-ui/blob/master/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**

![Cute seahorse](https://user-images.githubusercontent.com/43951/200327521-58f36107-e511-4dc5-b8ea-28bda73d4795.png)
