### PR TITLE
"Select filter" button is active without selecting any saved filter w…

### DIFF
--- a/kafka-ui-react-app/src/components/Topics/Topic/Messages/Filters/SavedFilters.tsx
+++ b/kafka-ui-react-app/src/components/Topics/Topic/Messages/Filters/SavedFilters.tsx
@@ -51,6 +51,7 @@ const SavedFilters: FC<Props> = ({
       </>,
       () => {
         deleteFilter(index);
+        setSelectedFilter(-1);
       }
     );
   };
@@ -95,6 +96,7 @@ const SavedFilters: FC<Props> = ({
           buttonType="primary"
           type="button"
           onClick={activateFilter}
+          disabled={selectedFilter === -1}
         >
           Select filter
         </Button>

--- a/kafka-ui-react-app/src/components/Topics/Topic/Messages/Filters/__tests__/SavedFilters.spec.tsx
+++ b/kafka-ui-react-app/src/components/Topics/Topic/Messages/Filters/__tests__/SavedFilters.spec.tsx
@@ -51,6 +51,9 @@ describe('SavedFilter Component', () => {
     it('should check the rendering of the empty filter', () => {
       expect(screen.getByText(/no saved filter/i)).toBeInTheDocument();
       expect(screen.queryByRole('savedFilter')).not.toBeInTheDocument();
+
+      const selectFilterBtn = screen.getByRole('button', { name: /Select filter/i });
+      expect(selectFilterBtn).toBeDisabled();
     });
   });
 
@@ -158,6 +161,9 @@ describe('SavedFilter Component', () => {
       await userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
       expect(deleteMock).toHaveBeenCalledTimes(1);
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+      const selectFilterBtn = screen.getByRole('button', { name: /Select filter/i });
+      expect(selectFilterBtn).toBeDisabled();
     });
   });
 });

--- a/kafka-ui-react-app/src/components/Topics/Topic/Messages/Filters/__tests__/SavedFilters.spec.tsx
+++ b/kafka-ui-react-app/src/components/Topics/Topic/Messages/Filters/__tests__/SavedFilters.spec.tsx
@@ -52,10 +52,8 @@ describe('SavedFilter Component', () => {
       expect(screen.getByText(/no saved filter/i)).toBeInTheDocument();
       expect(screen.queryByRole('savedFilter')).not.toBeInTheDocument();
 
-      const selectFilterBtn = screen.getByRole('button', {
-        name: /Select filter/i,
-      });
-      expect(selectFilterBtn).toBeDisabled();
+      const selectFilterButton = screen.getByText(/Select filter/i);
+      expect(selectFilterButton).toBeDisabled();
     });
   });
 
@@ -164,10 +162,8 @@ describe('SavedFilter Component', () => {
       expect(deleteMock).toHaveBeenCalledTimes(1);
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
 
-      const selectFilterBtn = screen.getByRole('button', {
-        name: /Select filter/i,
-      });
-      expect(selectFilterBtn).toBeDisabled();
+      const selectFilterButton = screen.getByText(/Select filter/i);
+      expect(selectFilterButton).toBeDisabled();
     });
   });
 });

--- a/kafka-ui-react-app/src/components/Topics/Topic/Messages/Filters/__tests__/SavedFilters.spec.tsx
+++ b/kafka-ui-react-app/src/components/Topics/Topic/Messages/Filters/__tests__/SavedFilters.spec.tsx
@@ -52,7 +52,9 @@ describe('SavedFilter Component', () => {
       expect(screen.getByText(/no saved filter/i)).toBeInTheDocument();
       expect(screen.queryByRole('savedFilter')).not.toBeInTheDocument();
 
-      const selectFilterBtn = screen.getByRole('button', { name: /Select filter/i });
+      const selectFilterBtn = screen.getByRole('button', {
+        name: /Select filter/i,
+      });
       expect(selectFilterBtn).toBeDisabled();
     });
   });
@@ -162,7 +164,9 @@ describe('SavedFilter Component', () => {
       expect(deleteMock).toHaveBeenCalledTimes(1);
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
 
-      const selectFilterBtn = screen.getByRole('button', { name: /Select filter/i });
+      const selectFilterBtn = screen.getByRole('button', {
+        name: /Select filter/i,
+      });
       expect(selectFilterBtn).toBeDisabled();
     });
   });

--- a/kafka-ui-react-app/src/components/Topics/Topic/Messages/Filters/__tests__/SavedFilters.spec.tsx
+++ b/kafka-ui-react-app/src/components/Topics/Topic/Messages/Filters/__tests__/SavedFilters.spec.tsx
@@ -120,7 +120,6 @@ describe('SavedFilter Component', () => {
     });
 
     it('Open Confirmation for the deletion modal', async () => {
-      setUpComponent({ deleteFilter: deleteMock });
       const savedFilters = getSavedFilters();
       const deleteIcons = screen.getAllByText('mock-DeleteIcon');
       await userEvent.hover(savedFilters[0]);
@@ -133,7 +132,6 @@ describe('SavedFilter Component', () => {
     });
 
     it('Close Confirmations deletion modal with button', async () => {
-      setUpComponent({ deleteFilter: deleteMock });
       const savedFilters = getSavedFilters();
       const deleteIcons = screen.getAllByText('mock-DeleteIcon');
 
@@ -150,7 +148,6 @@ describe('SavedFilter Component', () => {
     });
 
     it('Delete the saved filter', async () => {
-      setUpComponent({ deleteFilter: deleteMock });
       const savedFilters = getSavedFilters();
       const deleteIcons = screen.getAllByText('mock-DeleteIcon');
 


### PR DESCRIPTION
…ithin Topic/Messages/Saved filters

<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)


<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)

1. Only enable "Select filter" button when there is a saved filter selected.
2. Reset the selected saved filter when any saved filter is deleted.

**Is there anything you'd like reviewers to focus on?**


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (please, describe, if necessary)
- [ ] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/provectus/kafka-ui/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/provectus/kafka-ui/blob/master/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**
