### PR TITLE
Implement 404/403s on FE

### DIFF
--- a/kafka-ui-react-app/src/components/App.tsx
+++ b/kafka-ui-react-app/src/components/App.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense, useCallback } from 'react';
-import { Routes, Route, useLocation } from 'react-router-dom';
+import { Routes, Route, useLocation, Navigate } from 'react-router-dom';
 import { clusterPath, errorPage, getNonExactPath } from 'lib/paths';
 import Nav from 'components/Nav/Nav';
 import PageLoader from 'components/common/PageLoader/PageLoader';
@@ -125,6 +125,10 @@ const App: React.FC = () => {
                     element={<ClusterPage />}
                   />
                   <Route path={errorPage} element={<ErrorPage />} />
+                  <Route
+                    path="*"
+                    element={<Navigate to={errorPage} replace />}
+                  />
                 </Routes>
               </S.Container>
               <Toaster position="bottom-right" />

--- a/kafka-ui-react-app/src/components/App.tsx
+++ b/kafka-ui-react-app/src/components/App.tsx
@@ -1,6 +1,11 @@
 import React, { Suspense, useCallback } from 'react';
 import { Routes, Route, useLocation, Navigate } from 'react-router-dom';
-import { clusterPath, errorPage, getNonExactPath } from 'lib/paths';
+import {
+  accessErrorPage,
+  clusterPath,
+  errorPage,
+  getNonExactPath,
+} from 'lib/paths';
 import Nav from 'components/Nav/Nav';
 import PageLoader from 'components/common/PageLoader/PageLoader';
 import Dashboard from 'components/Dashboard/Dashboard';
@@ -123,6 +128,10 @@ const App: React.FC = () => {
                   <Route
                     path={getNonExactPath(clusterPath())}
                     element={<ClusterPage />}
+                  />
+                  <Route
+                    path={accessErrorPage}
+                    element={<ErrorPage status={403} text="Access is Denied" />}
                   />
                   <Route path={errorPage} element={<ErrorPage />} />
                   <Route

--- a/kafka-ui-react-app/src/components/App.tsx
+++ b/kafka-ui-react-app/src/components/App.tsx
@@ -1,6 +1,6 @@
 import React, { Suspense, useCallback } from 'react';
 import { Routes, Route, useLocation } from 'react-router-dom';
-import { clusterPath, getNonExactPath } from 'lib/paths';
+import { clusterPath, errorPage, getNonExactPath } from 'lib/paths';
 import Nav from 'components/Nav/Nav';
 import PageLoader from 'components/common/PageLoader/PageLoader';
 import Dashboard from 'components/Dashboard/Dashboard';
@@ -20,6 +20,7 @@ import DiscordIcon from 'components/common/Icons/DiscordIcon';
 import ConfirmationModal from './common/ConfirmationModal/ConfirmationModal';
 import { ConfirmContextProvider } from './contexts/ConfirmContext';
 import { GlobalSettingsProvider } from './contexts/GlobalSettingsContext';
+import ErrorPage from './ErrorPage/ErrorPage';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -123,6 +124,7 @@ const App: React.FC = () => {
                     path={getNonExactPath(clusterPath())}
                     element={<ClusterPage />}
                   />
+                  <Route path={errorPage} element={<ErrorPage />} />
                 </Routes>
               </S.Container>
               <Toaster position="bottom-right" />

--- a/kafka-ui-react-app/src/components/Brokers/Brokers.tsx
+++ b/kafka-ui-react-app/src/components/Brokers/Brokers.tsx
@@ -3,11 +3,19 @@ import { Route, Routes } from 'react-router-dom';
 import { getNonExactPath, RouteParams } from 'lib/paths';
 import BrokersList from 'components/Brokers/BrokersList/BrokersList';
 import Broker from 'components/Brokers/Broker/Broker';
+import SuspenseQueryComponent from 'components/common/SuspenseQueryComponent/SuspenseQueryComponent';
 
 const Brokers: React.FC = () => (
   <Routes>
     <Route index element={<BrokersList />} />
-    <Route path={getNonExactPath(RouteParams.brokerId)} element={<Broker />} />
+    <Route
+      path={getNonExactPath(RouteParams.brokerId)}
+      element={
+        <SuspenseQueryComponent>
+          <Broker />
+        </SuspenseQueryComponent>
+      }
+    />
   </Routes>
 );
 

--- a/kafka-ui-react-app/src/components/Connect/Connect.tsx
+++ b/kafka-ui-react-app/src/components/Connect/Connect.tsx
@@ -9,6 +9,7 @@ import {
   clusterConnectorsPath,
 } from 'lib/paths';
 import useAppParams from 'lib/hooks/useAppParams';
+import SuspenseQueryComponent from 'components/common/SuspenseQueryComponent/SuspenseQueryComponent';
 
 import ListPage from './List/ListPage';
 import New from './New/New';
@@ -23,7 +24,11 @@ const Connect: React.FC = () => {
       <Route path={clusterConnectorNewRelativePath} element={<New />} />
       <Route
         path={getNonExactPath(clusterConnectConnectorRelativePath)}
-        element={<DetailsPage />}
+        element={
+          <SuspenseQueryComponent>
+            <DetailsPage />
+          </SuspenseQueryComponent>
+        }
       />
       <Route
         path={clusterConnectConnectorsRelativePath}

--- a/kafka-ui-react-app/src/components/ErrorPage/ErrorPage.styled.ts
+++ b/kafka-ui-react-app/src/components/ErrorPage/ErrorPage.styled.ts
@@ -1,0 +1,15 @@
+import styled from 'styled-components';
+
+export const Wrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  margin-top: 50px;
+`;
+
+export const Text = styled.div`
+  font-size: 60px;
+  color: ${({ theme }) => theme.errorPage.text};
+  line-height: initial;
+`;

--- a/kafka-ui-react-app/src/components/ErrorPage/ErrorPage.styled.ts
+++ b/kafka-ui-react-app/src/components/ErrorPage/ErrorPage.styled.ts
@@ -6,6 +6,7 @@ export const Wrapper = styled.div`
   align-items: center;
   flex-direction: column;
   gap: 20px;
+  margin-top: 100px;
 `;
 
 export const Number = styled.div`

--- a/kafka-ui-react-app/src/components/ErrorPage/ErrorPage.styled.ts
+++ b/kafka-ui-react-app/src/components/ErrorPage/ErrorPage.styled.ts
@@ -5,11 +5,15 @@ export const Wrapper = styled.div`
   justify-content: center;
   align-items: center;
   flex-direction: column;
-  margin-top: 50px;
+  gap: 20px;
+`;
+
+export const Number = styled.div`
+  font-size: 100px;
+  color: ${({ theme }) => theme.errorPage.text};
+  line-height: initial;
 `;
 
 export const Text = styled.div`
-  font-size: 60px;
-  color: ${({ theme }) => theme.errorPage.text};
-  line-height: initial;
+  font-size: 20px;
 `;

--- a/kafka-ui-react-app/src/components/ErrorPage/ErrorPage.tsx
+++ b/kafka-ui-react-app/src/components/ErrorPage/ErrorPage.tsx
@@ -3,13 +3,23 @@ import { Button } from 'components/common/Button/Button';
 
 import * as S from './ErrorPage.styled';
 
-const ErrorPage = () => {
+interface Props {
+  status?: number;
+  text?: string;
+  btnText?: string;
+}
+
+const ErrorPage: React.FC<Props> = ({
+  status = 404,
+  text = 'Page not found',
+  btnText = 'Go Back to Dashboard',
+}) => {
   return (
     <S.Wrapper>
-      <S.Number>404</S.Number>
-      <S.Text>Page is not found</S.Text>
+      <S.Number>{status}</S.Number>
+      <S.Text>{text}</S.Text>
       <Button buttonType="primary" buttonSize="M" to="/">
-        Go Back to Dashboard
+        {btnText}
       </Button>
     </S.Wrapper>
   );

--- a/kafka-ui-react-app/src/components/ErrorPage/ErrorPage.tsx
+++ b/kafka-ui-react-app/src/components/ErrorPage/ErrorPage.tsx
@@ -1,21 +1,17 @@
 import React from 'react';
 import { Button } from 'components/common/Button/Button';
-import PageHeading from 'components/common/PageHeading/PageHeading';
 
 import * as S from './ErrorPage.styled';
 
 const ErrorPage = () => {
   return (
-    <>
-      <PageHeading text="404" />
-      <S.Wrapper>
-        <S.Number>404</S.Number>
-        <S.Text>Page is not found</S.Text>
-        <Button buttonType="primary" buttonSize="M" to="/">
-          Go Back to Dashboard
-        </Button>
-      </S.Wrapper>
-    </>
+    <S.Wrapper>
+      <S.Number>404</S.Number>
+      <S.Text>Page is not found</S.Text>
+      <Button buttonType="primary" buttonSize="M" to="/">
+        Go Back to Dashboard
+      </Button>
+    </S.Wrapper>
   );
 };
 

--- a/kafka-ui-react-app/src/components/ErrorPage/ErrorPage.tsx
+++ b/kafka-ui-react-app/src/components/ErrorPage/ErrorPage.tsx
@@ -11,7 +11,7 @@ interface Props {
 
 const ErrorPage: React.FC<Props> = ({
   status = 404,
-  text = 'Page not found',
+  text = 'Page is not found',
   btnText = 'Go Back to Dashboard',
 }) => {
   return (

--- a/kafka-ui-react-app/src/components/ErrorPage/ErrorPage.tsx
+++ b/kafka-ui-react-app/src/components/ErrorPage/ErrorPage.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Button } from 'components/common/Button/Button';
+import PageHeading from 'components/common/PageHeading/PageHeading';
+
+import * as S from './ErrorPage.styled';
+
+const ErrorPage = () => {
+  return (
+    <>
+      <PageHeading text="404" />
+      <S.Wrapper>
+        <S.Text>404</S.Text>
+        <Button buttonType="primary" buttonSize="M" to="/">
+          Go Back to Dashboard
+        </Button>
+      </S.Wrapper>
+    </>
+  );
+};
+
+export default ErrorPage;

--- a/kafka-ui-react-app/src/components/ErrorPage/ErrorPage.tsx
+++ b/kafka-ui-react-app/src/components/ErrorPage/ErrorPage.tsx
@@ -9,7 +9,8 @@ const ErrorPage = () => {
     <>
       <PageHeading text="404" />
       <S.Wrapper>
-        <S.Text>404</S.Text>
+        <S.Number>404</S.Number>
+        <S.Text>Page is not found</S.Text>
         <Button buttonType="primary" buttonSize="M" to="/">
           Go Back to Dashboard
         </Button>

--- a/kafka-ui-react-app/src/components/ErrorPage/__tests__/ErrorPage.spec.tsx
+++ b/kafka-ui-react-app/src/components/ErrorPage/__tests__/ErrorPage.spec.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { render } from 'lib/testHelpers';
+import ErrorPage from 'components/ErrorPage/ErrorPage';
+
+describe('ErrorPage', () => {
+  it('should check Error Page rendering with default text', () => {
+    render(<ErrorPage />);
+  });
+  it('should check Error Page rendering with custom text', () => {});
+});

--- a/kafka-ui-react-app/src/components/ErrorPage/__tests__/ErrorPage.spec.tsx
+++ b/kafka-ui-react-app/src/components/ErrorPage/__tests__/ErrorPage.spec.tsx
@@ -1,10 +1,24 @@
 import React from 'react';
+import { screen } from '@testing-library/react';
 import { render } from 'lib/testHelpers';
 import ErrorPage from 'components/ErrorPage/ErrorPage';
 
 describe('ErrorPage', () => {
   it('should check Error Page rendering with default text', () => {
     render(<ErrorPage />);
+    expect(screen.getByText('404')).toBeInTheDocument();
+    expect(screen.getByText('Page is not found')).toBeInTheDocument();
+    expect(screen.getByText('Go Back to Dashboard')).toBeInTheDocument();
   });
-  it('should check Error Page rendering with custom text', () => {});
+  it('should check Error Page rendering with custom text', () => {
+    const props = {
+      status: 403,
+      text: 'access is denied',
+      btnText: 'Go back',
+    };
+    render(<ErrorPage {...props} />);
+    expect(screen.getByText(props.status)).toBeInTheDocument();
+    expect(screen.getByText(props.text)).toBeInTheDocument();
+    expect(screen.getByText(props.btnText)).toBeInTheDocument();
+  });
 });

--- a/kafka-ui-react-app/src/components/Schemas/Details/Details.tsx
+++ b/kafka-ui-react-app/src/components/Schemas/Details/Details.tsx
@@ -20,6 +20,7 @@ import {
   SCHEMA_LATEST_FETCH_ACTION,
   selectAllSchemaVersions,
   getSchemaLatest,
+  getAreSchemaLatestRejected,
 } from 'redux/reducers/schemas/schemasSlice';
 import { showServerError } from 'lib/errorHandling';
 import { resetLoaderById } from 'redux/reducers/loader/loaderSlice';
@@ -55,6 +56,7 @@ const Details: React.FC = () => {
   const versions = useAppSelector((state) => selectAllSchemaVersions(state));
   const schema = useAppSelector(getSchemaLatest);
   const isFetched = useAppSelector(getAreSchemaLatestFulfilled);
+  const isRejected = useAppSelector(getAreSchemaLatestRejected);
   const areVersionsFetched = useAppSelector(getAreSchemaVersionsFulfilled);
 
   const columns = React.useMemo(
@@ -77,6 +79,10 @@ const Details: React.FC = () => {
       showServerError(e as Response);
     }
   };
+
+  if (isRejected) {
+    navigate('/404');
+  }
 
   if (!isFetched || !schema) {
     return <PageLoader />;

--- a/kafka-ui-react-app/src/components/Schemas/Edit/Edit.tsx
+++ b/kafka-ui-react-app/src/components/Schemas/Edit/Edit.tsx
@@ -25,6 +25,7 @@ import {
   SCHEMA_LATEST_FETCH_ACTION,
   getAreSchemaLatestFulfilled,
   schemaUpdated,
+  getAreSchemaLatestRejected,
 } from 'redux/reducers/schemas/schemasSlice';
 import PageLoader from 'components/common/PageLoader/PageLoader';
 import { resetLoaderById } from 'redux/reducers/loader/loaderSlice';
@@ -54,6 +55,7 @@ const Edit: React.FC = () => {
 
   const schema = useAppSelector((state) => getSchemaLatest(state));
   const isFetched = useAppSelector(getAreSchemaLatestFulfilled);
+  const isRejected = useAppSelector(getAreSchemaLatestRejected);
 
   const formatedSchema = React.useMemo(() => {
     return schema?.schemaType === SchemaType.PROTOBUF
@@ -97,6 +99,10 @@ const Edit: React.FC = () => {
       showServerError(e as Response);
     }
   };
+
+  if (isRejected) {
+    navigate('/404');
+  }
 
   if (!isFetched || !schema) {
     return <PageLoader />;

--- a/kafka-ui-react-app/src/components/Schemas/Schemas.tsx
+++ b/kafka-ui-react-app/src/components/Schemas/Schemas.tsx
@@ -11,13 +11,21 @@ import Details from 'components/Schemas/Details/Details';
 import New from 'components/Schemas/New/New';
 import Edit from 'components/Schemas/Edit/Edit';
 import DiffContainer from 'components/Schemas/Diff/DiffContainer';
+import SuspenseQueryComponent from 'components/common/SuspenseQueryComponent/SuspenseQueryComponent';
 
 const Schemas: React.FC = () => {
   return (
     <Routes>
       <Route index element={<List />} />
       <Route path={clusterSchemaNewRelativePath} element={<New />} />
-      <Route path={RouteParams.subject} element={<Details />} />
+      <Route
+        path={RouteParams.subject}
+        element={
+          <SuspenseQueryComponent>
+            <Details />
+          </SuspenseQueryComponent>
+        }
+      />
       <Route path={clusterSchemaEditRelativePath} element={<Edit />} />
       <Route
         path={clusterSchemaSchemaDiffRelativePath}

--- a/kafka-ui-react-app/src/components/Schemas/Schemas.tsx
+++ b/kafka-ui-react-app/src/components/Schemas/Schemas.tsx
@@ -11,21 +11,13 @@ import Details from 'components/Schemas/Details/Details';
 import New from 'components/Schemas/New/New';
 import Edit from 'components/Schemas/Edit/Edit';
 import DiffContainer from 'components/Schemas/Diff/DiffContainer';
-import SuspenseQueryComponent from 'components/common/SuspenseQueryComponent/SuspenseQueryComponent';
 
 const Schemas: React.FC = () => {
   return (
     <Routes>
       <Route index element={<List />} />
       <Route path={clusterSchemaNewRelativePath} element={<New />} />
-      <Route
-        path={RouteParams.subject}
-        element={
-          <SuspenseQueryComponent>
-            <Details />
-          </SuspenseQueryComponent>
-        }
-      />
+      <Route path={RouteParams.subject} element={<Details />} />
       <Route path={clusterSchemaEditRelativePath} element={<Edit />} />
       <Route
         path={clusterSchemaSchemaDiffRelativePath}

--- a/kafka-ui-react-app/src/components/Topics/Topics.tsx
+++ b/kafka-ui-react-app/src/components/Topics/Topics.tsx
@@ -6,6 +6,7 @@ import {
   getNonExactPath,
   RouteParams,
 } from 'lib/paths';
+import SuspenseQueryComponent from 'components/common/SuspenseQueryComponent/SuspenseQueryComponent';
 
 import New from './New/New';
 import ListPage from './List/ListPage';
@@ -16,7 +17,14 @@ const Topics: React.FC = () => (
     <Route index element={<ListPage />} />
     <Route path={clusterTopicNewRelativePath} element={<New />} />
     <Route path={clusterTopicCopyRelativePath} element={<New />} />
-    <Route path={getNonExactPath(RouteParams.topicName)} element={<Topic />} />
+    <Route
+      path={getNonExactPath(RouteParams.topicName)}
+      element={
+        <SuspenseQueryComponent>
+          <Topic />
+        </SuspenseQueryComponent>
+      }
+    />
   </Routes>
 );
 

--- a/kafka-ui-react-app/src/components/common/SuspenseQueryComponent/SuspenseQueryComponent.tsx
+++ b/kafka-ui-react-app/src/components/common/SuspenseQueryComponent/SuspenseQueryComponent.tsx
@@ -7,6 +7,8 @@ import { Navigate } from 'react-router-dom';
  * basic idea that you can not choose a wrong url, that is why you are safe, but when
  * the user tries to manipulate some url to get the the desired result and the BE returns 404
  * it will be propagated to this component and redirected
+ *
+ * !!NOTE!! But only use this Component for GET query Throw error cause maybe in the future inner functionality may change
  * */
 const SuspenseQueryComponent: React.FC<PropsWithChildren<unknown>> = ({
   children,

--- a/kafka-ui-react-app/src/components/common/SuspenseQueryComponent/SuspenseQueryComponent.tsx
+++ b/kafka-ui-react-app/src/components/common/SuspenseQueryComponent/SuspenseQueryComponent.tsx
@@ -1,0 +1,19 @@
+import React, { PropsWithChildren } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
+import { Navigate } from 'react-router-dom';
+
+/**
+ * @description
+ * basic idea that you can not choose a wrong url, that is why you are safe, but when
+ * the user tries to manipulate some url to get the the desired result and the BE returns 404
+ * it will be propagated to this component and redirected
+ * */
+const SuspenseQueryComponent: React.FC<PropsWithChildren<unknown>> = ({
+  children,
+}) => {
+  return (
+    <ErrorBoundary fallback={<Navigate to="/404" />}>{children}</ErrorBoundary>
+  );
+};
+
+export default SuspenseQueryComponent;

--- a/kafka-ui-react-app/src/components/common/SuspenseQueryComponent/SuspenseQueryComponent.tsx
+++ b/kafka-ui-react-app/src/components/common/SuspenseQueryComponent/SuspenseQueryComponent.tsx
@@ -2,6 +2,14 @@ import React, { PropsWithChildren } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { Navigate } from 'react-router-dom';
 
+const ErrorComponent: React.FC<{ error: Error }> = ({ error }) => {
+  const errorStatus = (error as unknown as Response)?.status
+    ? (error as unknown as Response).status
+    : '404';
+
+  return <Navigate to={`/${errorStatus}`} />;
+};
+
 /**
  * @description
  * basic idea that you can not choose a wrong url, that is why you are safe, but when
@@ -14,7 +22,7 @@ const SuspenseQueryComponent: React.FC<PropsWithChildren<unknown>> = ({
   children,
 }) => {
   return (
-    <ErrorBoundary fallback={<Navigate to="/404" />}>{children}</ErrorBoundary>
+    <ErrorBoundary FallbackComponent={ErrorComponent}>{children}</ErrorBoundary>
   );
 };
 

--- a/kafka-ui-react-app/src/components/common/SuspenseQueryComponent/__test__/SuspenseQueryComponent.spec.tsx
+++ b/kafka-ui-react-app/src/components/common/SuspenseQueryComponent/__test__/SuspenseQueryComponent.spec.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { render } from 'lib/testHelpers';
+import { screen } from '@testing-library/react';
+import SuspenseQueryComponent from 'components/common/SuspenseQueryComponent/SuspenseQueryComponent';
+
+const fallback = 'fallback';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  Navigate: () => <div>{fallback}</div>,
+}));
+
+describe('SuspenseQueryComponent', () => {
+  const text = 'text';
+
+  it('should render the inner component if no error occurs', () => {
+    render(<SuspenseQueryComponent>{text}</SuspenseQueryComponent>);
+    expect(screen.getByText(text)).toBeInTheDocument();
+  });
+
+  it('should not render the inner component and call navigate', () => {
+    // throwing intentional For error boundaries to work
+    jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const Component = () => {
+      throw new Error('new Error');
+    };
+
+    render(
+      <SuspenseQueryComponent>
+        <Component />
+      </SuspenseQueryComponent>
+    );
+    expect(screen.queryByText(text)).not.toBeInTheDocument();
+    expect(screen.getByText(fallback)).toBeInTheDocument();
+    jest.clearAllMocks();
+  });
+});

--- a/kafka-ui-react-app/src/lib/paths.ts
+++ b/kafka-ui-react-app/src/lib/paths.ts
@@ -24,6 +24,7 @@ export enum RouteParams {
 export const getNonExactPath = (path: string) => `${path}/*`;
 
 export const errorPage = '/404';
+export const accessErrorPage = '/403';
 
 export const clusterPath = (
   clusterName: ClusterName = RouteParams.clusterName

--- a/kafka-ui-react-app/src/lib/paths.ts
+++ b/kafka-ui-react-app/src/lib/paths.ts
@@ -23,6 +23,8 @@ export enum RouteParams {
 
 export const getNonExactPath = (path: string) => `${path}/*`;
 
+export const errorPage = '/404';
+
 export const clusterPath = (
   clusterName: ClusterName = RouteParams.clusterName
 ) => `/ui/clusters/${clusterName}`;

--- a/kafka-ui-react-app/src/redux/reducers/schemas/schemasSlice.ts
+++ b/kafka-ui-react-app/src/redux/reducers/schemas/schemasSlice.ts
@@ -134,6 +134,11 @@ export const getAreSchemaLatestFulfilled = createSelector(
   createFetchingSelector(SCHEMA_LATEST_FETCH_ACTION),
   (status) => status === AsyncRequestStatus.fulfilled
 );
+export const getAreSchemaLatestRejected = createSelector(
+  createFetchingSelector(SCHEMA_LATEST_FETCH_ACTION),
+  (status) => status === AsyncRequestStatus.rejected
+);
+
 export const getAreSchemaVersionsFulfilled = createSelector(
   createFetchingSelector(SCHEMAS_VERSIONS_FETCH_ACTION),
   (status) => status === AsyncRequestStatus.fulfilled

--- a/kafka-ui-react-app/src/theme/theme.ts
+++ b/kafka-ui-react-app/src/theme/theme.ts
@@ -581,6 +581,9 @@ const theme = {
   statictics: {
     createdAtColor: Colors.neutral[50],
   },
+  errorPage: {
+    text: Colors.blue[45],
+  },
 };
 
 export type ThemeType = typeof theme;


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)


<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)
Handle the Error case when a request 404 flag , that was breaking the page where we were using `Query`, and getting stuck on an infinite load with redux , handle both of them separately, and mention in the issue clear way to migrate to the query case when the times comes.  

**Is there anything you'd like reviewers to focus on?**


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (please, describe, if necessary)
- [x] Unit checks
- [ ] Integration checks
- [x] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/provectus/kafka-ui/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/provectus/kafka-ui/blob/master/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**
