### PR TITLE
MessagesServiceTest:maskingAppliedOnConfiguredClusters fix

### DIFF
--- a/kafka-ui-api/src/test/java/com/provectus/kafka/ui/service/MessagesServiceTest.java
+++ b/kafka-ui-api/src/test/java/com/provectus/kafka/ui/service/MessagesServiceTest.java
@@ -61,12 +61,12 @@ class MessagesServiceTest extends AbstractIntegrationTest {
   }
 
   @Test
-  void maskingAppliedOnConfiguredClusters() {
+  void maskingAppliedOnConfiguredClusters() throws Exception {
     String testTopic = MASKED_TOPICS_PREFIX + UUID.randomUUID();
     try (var producer = KafkaTestProducer.forKafka(kafka)) {
       createTopic(new NewTopic(testTopic, 1, (short) 1));
       producer.send(testTopic, "message1");
-      producer.send(testTopic, "message2");
+      producer.send(testTopic, "message2").get();
 
       Flux<TopicMessageDTO> msgsFlux = messagesService.loadMessages(
           cluster,


### PR DESCRIPTION
MessagesServiceTest.maskingAppliedOnConfiguredClusters : waiting of kafka write added

<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)


<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)

**Is there anything you'd like reviewers to focus on?**


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (please, describe, if necessary)
- [x] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/provectus/kafka-ui/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/provectus/kafka-ui/blob/master/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**
