### PR TITLE
Fix serialization doc regarding serde configs

### DIFF
--- a/documentation/guides/Serialization.md
+++ b/documentation/guides/Serialization.md
@@ -20,7 +20,7 @@ kafka:
   clusters:
     - name: Cluster1
       # Other Cluster configuration omitted ... 
-      serdes:
+      serde:
           # registering String serde with custom config
         - name: AsciiString
           className: com.provectus.kafka.ui.serdes.builtin.StringSerde
@@ -43,7 +43,7 @@ kafka:
   clusters:
     - name: Cluster1
       # Other Cluster configuration omitted ... 
-      serdes:
+      serde:
         - name: ProtobufFile
           properties:
             # path to the protobuf schema files
@@ -84,7 +84,7 @@ kafka:
     - name: Cluster1
       # this url will be used by "SchemaRegistry" by default
       schemaRegistry: http://main-schema-registry:8081
-      serdes:
+      serde:
         - name: AnotherSchemaRegistry
           className: com.provectus.kafka.ui.serdes.builtin.sr.SchemaRegistrySerde
           properties:
@@ -109,7 +109,7 @@ Sample configuration:
 kafka:
   clusters:
     - name: Cluster1
-      serdes:
+      serde:
         - name: String
           topicKeysPattern: click-events|imp-events
         
@@ -131,7 +131,7 @@ kafka:
     - name: Cluster1
       defaultKeySerde: Int32
       defaultValueSerde: String
-      serdes:
+      serde:
         - name: Int32
           topicKeysPattern: click-events|imp-events
 ```
@@ -156,7 +156,7 @@ Sample configuration:
 kafka:
   clusters:
     - name: Cluster1
-      serdes:
+      serde:
         - name: MyCustomSerde
           className: my.lovely.org.KafkaUiSerde
           filePath: /var/lib/kui-serde/my-kui-serde.jar


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)


<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)
The `serdes` field does nothing in the `application.conf` and the right one is `serde`. I think it comes from this [line](https://github.com/provectus/kafka-ui/blob/f2ec4d76de481f1a049ae59c4c6fa352bdab7a30/kafka-ui-api/src/main/java/com/provectus/kafka/ui/config/ClustersProperties.java#L41) but I'm not familiar enough with Go to be sure.

**Is there anything you'd like reviewers to focus on?**
We can either change the field name to `serdes` in the `ClusterPropertios` class, or change the docs to fit the field name.

**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [x] No need to
- [ ] Manually (please, describe, if necessary)
- [ ] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

Check out [Contributing](https://github.com/provectus/kafka-ui/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/provectus/kafka-ui/blob/master/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**
