### PR TITLE
Fix number of partitions field validation issue

### DIFF
--- a/kafka-ui-react-app/src/components/Topics/shared/Form/TopicForm.tsx
+++ b/kafka-ui-react-app/src/components/Topics/shared/Form/TopicForm.tsx
@@ -116,6 +116,7 @@ const TopicForm: React.FC<Props> = ({
                   min="1"
                   name="partitions"
                   positiveOnly
+                  integerOnly
                 />
                 <FormError>
                   <ErrorMessage errors={errors} name="partitions" />
@@ -162,6 +163,7 @@ const TopicForm: React.FC<Props> = ({
               min="1"
               name="minInSyncReplicas"
               positiveOnly
+              integerOnly
             />
             <FormError>
               <ErrorMessage errors={errors} name="minInSyncReplicas" />
@@ -179,6 +181,7 @@ const TopicForm: React.FC<Props> = ({
                 min="1"
                 name="replicationFactor"
                 positiveOnly
+                integerOnly
               />
               <FormError>
                 <ErrorMessage errors={errors} name="replicationFactor" />
@@ -230,6 +233,7 @@ const TopicForm: React.FC<Props> = ({
               min="1"
               name="maxMessageBytes"
               positiveOnly
+              integerOnly
             />
             <FormError>
               <ErrorMessage errors={errors} name="maxMessageBytes" />

--- a/kafka-ui-react-app/src/components/Topics/shared/Form/TopicForm.tsx
+++ b/kafka-ui-react-app/src/components/Topics/shared/Form/TopicForm.tsx
@@ -115,7 +115,6 @@ const TopicForm: React.FC<Props> = ({
                   placeholder="Number of partitions"
                   min="1"
                   name="partitions"
-                  positiveOnly
                 />
                 <FormError>
                   <ErrorMessage errors={errors} name="partitions" />
@@ -161,7 +160,6 @@ const TopicForm: React.FC<Props> = ({
               placeholder="Min In Sync Replicas"
               min="1"
               name="minInSyncReplicas"
-              positiveOnly
             />
             <FormError>
               <ErrorMessage errors={errors} name="minInSyncReplicas" />
@@ -178,7 +176,6 @@ const TopicForm: React.FC<Props> = ({
                 placeholder="Replication Factor"
                 min="1"
                 name="replicationFactor"
-                positiveOnly
               />
               <FormError>
                 <ErrorMessage errors={errors} name="replicationFactor" />
@@ -229,7 +226,6 @@ const TopicForm: React.FC<Props> = ({
               placeholder="Maximum message size"
               min="1"
               name="maxMessageBytes"
-              positiveOnly
             />
             <FormError>
               <ErrorMessage errors={errors} name="maxMessageBytes" />

--- a/kafka-ui-react-app/src/components/Topics/shared/Form/TopicForm.tsx
+++ b/kafka-ui-react-app/src/components/Topics/shared/Form/TopicForm.tsx
@@ -115,6 +115,7 @@ const TopicForm: React.FC<Props> = ({
                   placeholder="Number of partitions"
                   min="1"
                   name="partitions"
+                  positiveOnly
                 />
                 <FormError>
                   <ErrorMessage errors={errors} name="partitions" />
@@ -160,6 +161,7 @@ const TopicForm: React.FC<Props> = ({
               placeholder="Min In Sync Replicas"
               min="1"
               name="minInSyncReplicas"
+              positiveOnly
             />
             <FormError>
               <ErrorMessage errors={errors} name="minInSyncReplicas" />
@@ -176,6 +178,7 @@ const TopicForm: React.FC<Props> = ({
                 placeholder="Replication Factor"
                 min="1"
                 name="replicationFactor"
+                positiveOnly
               />
               <FormError>
                 <ErrorMessage errors={errors} name="replicationFactor" />
@@ -226,6 +229,7 @@ const TopicForm: React.FC<Props> = ({
               placeholder="Maximum message size"
               min="1"
               name="maxMessageBytes"
+              positiveOnly
             />
             <FormError>
               <ErrorMessage errors={errors} name="maxMessageBytes" />

--- a/kafka-ui-react-app/src/components/common/Input/Input.tsx
+++ b/kafka-ui-react-app/src/components/common/Input/Input.tsx
@@ -23,6 +23,20 @@ const Input: React.FC<InputProps> = ({
   ...rest
 }) => {
   const methods = useFormContext();
+
+  const inputNumberCheck = (key: string, code: string) => {
+    let isValid: boolean;
+    if (!((key >= '0' && key <= '9') || key === '-' || code === 'Minus')) {
+      // If not a valid digit.
+      isValid = false;
+    } else if (positiveOnly) {
+      isValid = !(key === '-' || code === 'Minus');
+    } else {
+      isValid = true;
+    }
+    return isValid;
+  };
+
   const keyPressEventHandler = (
     event: React.KeyboardEvent<HTMLInputElement>
   ) => {
@@ -30,10 +44,7 @@ const Input: React.FC<InputProps> = ({
     if (type === 'number') {
       // Manually prevent input of non-digit and non-minus for all number inputs
       // and prevent input of negative numbers for positiveOnly inputs
-      if (
-        !((key >= '0' && key <= '9') || key === '-' || code === 'Minus') ||
-        (positiveOnly && (key === '-' || code === 'Minus'))
-      ) {
+      if (!inputNumberCheck(key, code)) {
         event.preventDefault();
       }
     }

--- a/kafka-ui-react-app/src/components/common/Input/Input.tsx
+++ b/kafka-ui-react-app/src/components/common/Input/Input.tsx
@@ -13,6 +13,19 @@ export interface InputProps
   positiveOnly?: boolean;
 }
 
+function inputNumberCheck(key: string, code: string, positiveOnly: boolean) {
+  let isValid: boolean;
+  if (!((key >= '0' && key <= '9') || key === '-' || code === 'Minus')) {
+    // If not a valid digit.
+    isValid = false;
+  } else if (positiveOnly) {
+    isValid = !(key === '-' || code === 'Minus');
+  } else {
+    isValid = true;
+  }
+  return isValid;
+}
+
 const Input: React.FC<InputProps> = ({
   name,
   hookFormOptions,
@@ -24,19 +37,6 @@ const Input: React.FC<InputProps> = ({
 }) => {
   const methods = useFormContext();
 
-  const inputNumberCheck = (key: string, code: string) => {
-    let isValid: boolean;
-    if (!((key >= '0' && key <= '9') || key === '-' || code === 'Minus')) {
-      // If not a valid digit.
-      isValid = false;
-    } else if (positiveOnly) {
-      isValid = !(key === '-' || code === 'Minus');
-    } else {
-      isValid = true;
-    }
-    return isValid;
-  };
-
   const keyPressEventHandler = (
     event: React.KeyboardEvent<HTMLInputElement>
   ) => {
@@ -44,7 +44,13 @@ const Input: React.FC<InputProps> = ({
     if (type === 'number') {
       // Manually prevent input of non-digit and non-minus for all number inputs
       // and prevent input of negative numbers for positiveOnly inputs
-      if (!inputNumberCheck(key, code)) {
+      if (
+        !inputNumberCheck(
+          key,
+          code,
+          typeof positiveOnly === 'boolean' ? positiveOnly : false
+        )
+      ) {
         event.preventDefault();
       }
     }

--- a/kafka-ui-react-app/src/components/common/Input/Input.tsx
+++ b/kafka-ui-react-app/src/components/common/Input/Input.tsx
@@ -28,9 +28,12 @@ const Input: React.FC<InputProps> = ({
   ) => {
     const { key, code } = event;
     if (type === 'number') {
-      // Manualy prevent input of 'e' character for all number inputs
+      // Manually prevent input of non-digit and non-minus for all number inputs
       // and prevent input of negative numbers for positiveOnly inputs
-      if (key === 'e' || (positiveOnly && (key === '-' || code === 'Minus'))) {
+      if (
+        !((key >= '0' && key <= '9') || key === '-' || code === 'Minus') ||
+        (positiveOnly && (key === '-' || code === 'Minus'))
+      ) {
         event.preventDefault();
       }
     }

--- a/kafka-ui-react-app/src/components/common/Input/Input.tsx
+++ b/kafka-ui-react-app/src/components/common/Input/Input.tsx
@@ -28,12 +28,9 @@ const Input: React.FC<InputProps> = ({
   ) => {
     const { key, code } = event;
     if (type === 'number') {
-      // Manually prevent input of non-digit and non-minus for all number inputs
+      // Manualy prevent input of 'e' character for all number inputs
       // and prevent input of negative numbers for positiveOnly inputs
-      if (
-        !((key >= '0' && key <= '9') || key === '-' || code === 'Minus') ||
-        (positiveOnly && (key === '-' || code === 'Minus'))
-      ) {
+      if (key === 'e' || (positiveOnly && (key === '-' || code === 'Minus'))) {
         event.preventDefault();
       }
     }

--- a/kafka-ui-react-app/src/components/common/Input/__tests__/Input.spec.tsx
+++ b/kafka-ui-react-app/src/components/common/Input/__tests__/Input.spec.tsx
@@ -32,14 +32,14 @@ describe('Custom Input', () => {
       expect(input).toHaveValue(131);
     });
 
-    it('allows negative values', async () => {
+    it('allows user to type negative values', async () => {
       render(setupWrapper({ type: 'number' }));
       const input = getInput();
       await userEvent.type(input, '-2');
       expect(input).toHaveValue(-2);
     });
 
-    it('allow positive values only', async () => {
+    it('allows user to type positive values only', async () => {
       render(setupWrapper({ type: 'number', positiveOnly: true }));
       const input = getInput();
       await userEvent.type(input, '-2');

--- a/kafka-ui-react-app/src/components/common/Input/__tests__/Input.spec.tsx
+++ b/kafka-ui-react-app/src/components/common/Input/__tests__/Input.spec.tsx
@@ -38,5 +38,12 @@ describe('Custom Input', () => {
       await userEvent.type(input, '-2');
       expect(input).toHaveValue(-2);
     });
+
+    it('allow positive values only', async () => {
+      render(setupWrapper({ type: 'number', positiveOnly: true }));
+      const input = getInput();
+      await userEvent.type(input, '-2');
+      expect(input).toHaveValue(2);
+    });
   });
 });

--- a/kafka-ui-react-app/src/components/common/Input/__tests__/Input.spec.tsx
+++ b/kafka-ui-react-app/src/components/common/Input/__tests__/Input.spec.tsx
@@ -4,12 +4,23 @@ import { screen } from '@testing-library/react';
 import { render } from 'lib/testHelpers';
 import userEvent from '@testing-library/user-event';
 
+// Mock useFormContext
+let component: HTMLInputElement;
+
 const setupWrapper = (props?: Partial<InputProps>) => (
   <Input name="test" {...props} />
 );
 jest.mock('react-hook-form', () => ({
   useFormContext: () => ({
     register: jest.fn(),
+
+    // Mock methods.getValues and methods.setValue
+    getValues: jest.fn(() => {
+      return component.value;
+    }),
+    setValue: jest.fn((key, val) => {
+      component.value = val;
+    }),
   }),
 }));
 
@@ -23,27 +34,146 @@ describe('Custom Input', () => {
     });
   });
   describe('number', () => {
-    const getInput = () => screen.getByRole('spinbutton');
+    const getInput = () => screen.getByRole<HTMLInputElement>('spinbutton');
 
-    it('allows user to type only numbers', async () => {
-      render(setupWrapper({ type: 'number' }));
-      const input = getInput();
-      await userEvent.type(input, 'abc131');
-      expect(input).toHaveValue(131);
+    describe('input', () => {
+      it('allows user to type numbers only', async () => {
+        render(setupWrapper({ type: 'number' }));
+        const input = getInput();
+        component = input;
+        await userEvent.type(input, 'abc131');
+        expect(input).toHaveValue(131);
+      });
+
+      it('allows user to type negative values', async () => {
+        render(setupWrapper({ type: 'number' }));
+        const input = getInput();
+        component = input;
+        await userEvent.type(input, '-2');
+        expect(input).toHaveValue(-2);
+      });
+
+      it('allows user to type positive values only', async () => {
+        render(setupWrapper({ type: 'number', positiveOnly: true }));
+        const input = getInput();
+        component = input;
+        await userEvent.type(input, '-2');
+        expect(input).toHaveValue(2);
+      });
+
+      it('allows user to type decimal', async () => {
+        render(setupWrapper({ type: 'number' }));
+        const input = getInput();
+        component = input;
+        await userEvent.type(input, '2.3');
+        expect(input).toHaveValue(2.3);
+      });
+
+      it('allows user to type integer only', async () => {
+        render(setupWrapper({ type: 'number', integerOnly: true }));
+        const input = getInput();
+        component = input;
+        await userEvent.type(input, '2.3');
+        expect(input).toHaveValue(23);
+      });
+
+      it("not allow '-' appear at any position of the string except the start", async () => {
+        render(setupWrapper({ type: 'number' }));
+        const input = getInput();
+        component = input;
+        await userEvent.type(input, '2-3');
+        expect(input).toHaveValue(23);
+      });
+
+      it("not allow '.' appear at the start of the string", async () => {
+        render(setupWrapper({ type: 'number' }));
+        const input = getInput();
+        component = input;
+        await userEvent.type(input, '.33');
+        expect(input).toHaveValue(33);
+      });
+
+      it("not allow '.' appear twice in the string", async () => {
+        render(setupWrapper({ type: 'number' }));
+        const input = getInput();
+        component = input;
+        await userEvent.type(input, '3.3.3');
+        expect(input).toHaveValue(3.33);
+      });
     });
 
-    it('allows user to type negative values', async () => {
-      render(setupWrapper({ type: 'number' }));
-      const input = getInput();
-      await userEvent.type(input, '-2');
-      expect(input).toHaveValue(-2);
-    });
+    describe('paste', () => {
+      it('allows user to paste numbers only', async () => {
+        render(setupWrapper({ type: 'number' }));
+        const input = getInput();
+        component = input;
+        await userEvent.click(input);
+        await userEvent.paste('abc131');
+        expect(input).toHaveValue(131);
+      });
 
-    it('allows user to type positive values only', async () => {
-      render(setupWrapper({ type: 'number', positiveOnly: true }));
-      const input = getInput();
-      await userEvent.type(input, '-2');
-      expect(input).toHaveValue(2);
+      it('allows user to paste negative values', async () => {
+        render(setupWrapper({ type: 'number' }));
+        const input = getInput();
+        component = input;
+        await userEvent.click(input);
+        await userEvent.paste('-2');
+        expect(input).toHaveValue(-2);
+      });
+
+      it('allows user to paste positive values only', async () => {
+        render(setupWrapper({ type: 'number', positiveOnly: true }));
+        const input = getInput();
+        component = input;
+        await userEvent.click(input);
+        await userEvent.paste('-2');
+        expect(input).toHaveValue(2);
+      });
+
+      it('allows user to paste decimal', async () => {
+        render(setupWrapper({ type: 'number' }));
+        const input = getInput();
+        component = input;
+        await userEvent.click(input);
+        await userEvent.paste('2.3');
+        expect(input).toHaveValue(2.3);
+      });
+
+      it('allows user to paste integer only', async () => {
+        render(setupWrapper({ type: 'number', integerOnly: true }));
+        const input = getInput();
+        component = input;
+        await userEvent.click(input);
+        await userEvent.paste('2.3');
+        expect(input).toHaveValue(23);
+      });
+
+      it("not allow '-' appear at any position of the pasted string except the start", async () => {
+        render(setupWrapper({ type: 'number' }));
+        const input = getInput();
+        component = input;
+        await userEvent.click(input);
+        await userEvent.paste('2-3');
+        expect(input).toHaveValue(23);
+      });
+
+      it("not allow '.' appear at the start of the pasted string", async () => {
+        render(setupWrapper({ type: 'number' }));
+        const input = getInput();
+        component = input;
+        await userEvent.click(input);
+        await userEvent.paste('.33');
+        expect(input).toHaveValue(0.33);
+      });
+
+      it("not allow '.' appear twice in the pasted string", async () => {
+        render(setupWrapper({ type: 'number' }));
+        const input = getInput();
+        component = input;
+        await userEvent.click(input);
+        await userEvent.paste('3.3.3');
+        expect(input).toHaveValue(3.33);
+      });
     });
   });
 });

--- a/kafka-ui-react-app/src/components/common/NewTable/__test__/Table.spec.tsx
+++ b/kafka-ui-react-app/src/components/common/NewTable/__test__/Table.spec.tsx
@@ -20,6 +20,17 @@ jest.mock('react-router-dom', () => ({
   useNavigate: () => mockedUsedNavigate,
 }));
 
+// This is needed by ESLint.
+jest.mock('react-hook-form', () => ({
+  useFormContext: () => ({
+    register: jest.fn(),
+
+    // Mock methods.getValues and methods.setValue
+    getValues: jest.fn(),
+    setValue: jest.fn(),
+  }),
+}));
+
 type Datum = typeof data[0];
 
 const data = [


### PR DESCRIPTION
Now user can only input valid digits, and '-' is not allowed in positive-only inputs.

<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)


<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)
Changed the condition to prevent the key-press event in number input boxes: only accept 0~9 and '-'.

**Is there anything you'd like reviewers to focus on?**


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [x] No need to
- [x] Manually (please, describe, if necessary)
Tested in the browser manually, and now only 0~9 and '-' can be inputted into the box. At the same time, positive-only boxes (like partition count) do not accept '-' anymore.
- [x] Unit checks
- [x] Integration checks
- [x] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/provectus/kafka-ui/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/provectus/kafka-ui/blob/master/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**
