### PR TITLE
Helm: Add the `global.imageRegistry` parameter

### DIFF
--- a/charts/kafka-ui/Chart.yaml
+++ b/charts/kafka-ui/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: kafka-ui
 description: A Helm chart for kafka-UI
 type: application
-version: 0.5.3
+version: 0.5.4
 appVersion: v0.5.0
 icon: https://github.com/provectus/kafka-ui/raw/master/documentation/images/kafka-ui-logo.png

--- a/charts/kafka-ui/templates/_helpers.tpl
+++ b/charts/kafka-ui/templates/_helpers.tpl
@@ -68,6 +68,11 @@ This allows us to check if the registry of the image is specified or not.
 */}}
 {{- define "kafka-ui.imageName" -}}
 {{- $registryName := .Values.image.registry -}}
+{{- if .Values.global }}
+    {{- if .Values.global.imageRegistry }}
+     {{- $registryName = .Values.global.imageRegistry -}}
+    {{- end -}}
+{{- end -}}
 {{- $repository := .Values.image.repository -}}
 {{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
 {{- if $registryName }}


### PR DESCRIPTION
Now if this chart is used as a subchart, the image registry will be taken from `global.imageRegistry` (if it exists).

* Closes #3437 

<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)


<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)
I added code that checks if `global.imageRegistry` exists and if so, that will be used instead of `image.registry`. I also bumped the version in `Chart.yaml`.

**Is there anything you'd like reviewers to focus on?**
No

**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (please, describe, if necessary)
- [ ] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->
I used the following command: `helm template test charts/kafka-ui/ --set global.imageRegistry=container-registry.my-domain.com | yq e 'select(.kind == "Deployment") | .spec.template.spec.containers[].image'`

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged

**A picture of a cute animal (not mandatory but encouraged)**
![koala](https://i.pinimg.com/originals/dd/5b/01/dd5b01f0219c5d6afa30f954852f2e00.png)