### PR TITLE
Allow sorting consumer groups by messages behind

### DIFF
--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/mapper/ConsumerGroupMapper.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/mapper/ConsumerGroupMapper.java
@@ -89,19 +89,7 @@ public class ConsumerGroupMapper {
             .flatMap(m -> m.getAssignment().stream().map(TopicPartition::topic))
     ).collect(Collectors.toSet()).size();
 
-    Long messagesBehind = null;
-    // messagesBehind should be undefined if no committed offsets found for topic
-    if (!c.getOffsets().isEmpty()) {
-      messagesBehind = c.getOffsets().entrySet().stream()
-          .mapToLong(e ->
-              Optional.ofNullable(c.getEndOffsets())
-                  .map(o -> o.get(e.getKey()))
-                  .map(o -> o - e.getValue())
-                  .orElse(0L)
-          ).sum();
-    }
-
-    consumerGroup.setMessagesBehind(messagesBehind);
+    consumerGroup.setMessagesBehind(c.getMessagesBehind());
     consumerGroup.setTopics(numTopics);
     consumerGroup.setSimple(c.isSimple());
 

--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/service/ConsumerGroupService.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/service/ConsumerGroupService.java
@@ -157,6 +157,19 @@ public class ConsumerGroupService {
             .map(descriptions ->
                 sortAndPaginate(descriptions.values(), comparator, pageNum, perPage, sortOrderDto).toList());
       }
+      case BEHIND -> {
+        Comparator<InternalConsumerGroup> comparator = Comparator.comparingLong(icg ->
+            icg.getMessagesBehind() == null ? 0L : icg.getMessagesBehind());
+        var groupNames = groups.stream().map(ConsumerGroupListing::groupId).toList();
+        yield ac.describeConsumerGroups(groupNames)
+              .flatMap(descriptionsMap ->
+                  getConsumerGroups(ac, descriptionsMap.values().stream().toList())
+                    .map(internalGroups ->
+                      sortAndPaginate(internalGroups, comparator, pageNum, perPage, sortOrderDto).toList())
+                    .map(internalGroups ->
+                      internalGroups.stream().map(InternalConsumerGroup::getDescription).toList())
+              );
+      }
     };
   }
 

--- a/kafka-ui-contract/src/main/resources/swagger/kafka-ui-api.yaml
+++ b/kafka-ui-contract/src/main/resources/swagger/kafka-ui-api.yaml
@@ -2416,6 +2416,7 @@ components:
         - NAME
         - MEMBERS
         - STATE
+        - BEHIND
 
     ConsumerGroupsPageResponse:
       type: object

--- a/kafka-ui-react-app/src/components/ConsumerGroups/List/List.tsx
+++ b/kafka-ui-react-app/src/components/ConsumerGroups/List/List.tsx
@@ -68,9 +68,9 @@ const List: React.FC<Props> = ({ consumerGroups, totalPages }) => {
         enableSorting: false,
       },
       {
+        id: ConsumerGroupOrdering.BEHIND,
         header: 'Messages Behind',
         accessorKey: 'messagesBehind',
-        enableSorting: false,
       },
       {
         header: 'Coordinator',


### PR DESCRIPTION
* Closes #3468 

**What changes did you make?** (Give an overview)
* Added an additional value through the enum of ConsumerGroupOrdering
* Enabled sorting in the react consumer groups page (by messages behind)
* Moved the message behind calculation logic to InternalConsumerGroup as part of its creation
* Added the messages behind case - sorting internalConsumerGroup according to comparator with messages behind logic

**Is there anything you'd like reviewers to focus on?**
I added the consumerGroupDescription as a field into InternalConsumerGroup, so I could map it back after we sort. 

**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually -  I opened the ConsumerGroup Page and clicked on the messages behind column
- [ ] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged


**A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/78907315/226599281-5367d41a-8fbc-466e-b2ff-de2c6c1858b5.png)
