### PR TITLE
Allow 'Copy Selected Topic' button when action is Action.CREATE

### DIFF
--- a/kafka-ui-react-app/src/components/Topics/List/BatchActionsBar.tsx
+++ b/kafka-ui-react-app/src/components/Topics/List/BatchActionsBar.tsx
@@ -5,7 +5,6 @@ import useAppParams from 'lib/hooks/useAppParams';
 import { ClusterName } from 'redux/interfaces';
 import { topicKeys, useDeleteTopic } from 'lib/hooks/api/topics';
 import { useConfirm } from 'lib/hooks/useConfirm';
-import { Button } from 'components/common/Button/Button';
 import { useAppDispatch } from 'lib/hooks/redux';
 import { clearTopicMessages } from 'redux/reducers/topicMessages/topicMessagesSlice';
 import { clusterTopicCopyRelativePath } from 'lib/paths';
@@ -103,6 +102,19 @@ const BatchActionsbar: React.FC<BatchActionsbarProps> = ({
     );
   }, [selectedTopics, clusterName, roles]);
 
+  const canCopySelectedTopic = useMemo(() => {
+    return selectedTopics.every((value) =>
+      isPermitted({
+        roles,
+        resource: ResourceType.TOPIC,
+        action: Action.CREATE,
+        value,
+        clusterName,
+        rbacFlag,
+      })
+    );
+  }, [selectedTopics, clusterName, roles]);
+
   const canPurgeSelectedTopics = useMemo(() => {
     return selectedTopics.every((value) =>
       isPermitted({
@@ -127,14 +139,15 @@ const BatchActionsbar: React.FC<BatchActionsbarProps> = ({
       >
         Delete selected topics
       </ActionCanButton>
-      <Button
+      <ActionCanButton
         buttonSize="M"
         buttonType="secondary"
         disabled={selectedTopics.length !== 1}
+        canDoAction={canCopySelectedTopic}
         to={getCopyTopicPath()}
       >
         Copy selected topic
-      </Button>
+      </ActionCanButton>
       <ActionCanButton
         buttonSize="M"
         buttonType="secondary"


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)


<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)
"Copy selected topic" is enabled without Action.CREATE, So I disabled the button when user's action is not in Action.CREATE
- Changed Button to ActionCanButton
- Add Permission on button action


**Is there anything you'd like reviewers to focus on?**
No

**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (please, describe, if necessary)
- [ ] Unit checks
- [ ] Integration checks
- [x] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/provectus/kafka-ui/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/provectus/kafka-ui/blob/master/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/50516754/227481638-5a3e3a36-402c-400a-9f02-0963d226d481.png)
It is a bug that user cannot delete but can copy with same Action Permission