### PR TITLE
Fix dummy field in saved JSON message content

### DIFF
--- a/kafka-ui-react-app/src/components/Topics/Topic/Messages/Message.tsx
+++ b/kafka-ui-react-app/src/components/Topics/Topic/Messages/Message.tsx
@@ -51,7 +51,7 @@ const Message: React.FC<Props> = ({
 }) => {
   const [isOpen, setIsOpen] = React.useState(false);
   const savedMessageJson = {
-    Content: content,
+    Value: content,
     Offset: offset,
     Key: key,
     Partition: partition,


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)


<!-- ignore-task-list-end -->
**What changes did you make?** 

Fixes [issue/3250-Dummy field in content ](https://github.com/provectus/kafka-ui/issues/3250)

Following [this comment](https://github.com/provectus/kafka-ui/issues/2675#issuecomment-1386773808), there was a missing `Content` key to be replaced with `Value` when saving a message to JSON or copying it to the clipboard.  

**Is there anything you'd like reviewers to focus on?**

None.

**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (please, describe, if necessary)
- [ ] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

Tested adding a new message, downloading to a file, and checked if the  `Value` key existed instead of the `Content` one.

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/provectus/kafka-ui/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/provectus/kafka-ui/blob/master/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**
Sadly have no pets. :'(

Edit: missing items in checklist.
