### PR TITLE
Implement system redirects to Topics after topic delete #3044

### DIFF
--- a/kafka-ui-react-app/src/components/Topics/Topic/Messages/Filters/AddEditFilterContainer.tsx
+++ b/kafka-ui-react-app/src/components/Topics/Topic/Messages/Filters/AddEditFilterContainer.tsx
@@ -27,7 +27,7 @@ export interface AddEditFilterContainerProps {
   inputDisplayNameDefaultValue?: string;
   inputCodeDefaultValue?: string;
   isAdd?: boolean;
-  submitCallback?: (values: AddMessageFilters) => Promise<void>;
+  submitCallback?: (values: AddMessageFilters) => void;
 }
 
 const AddEditFilterContainer: React.FC<AddEditFilterContainerProps> = ({

--- a/kafka-ui-react-app/src/components/Topics/Topic/Topic.tsx
+++ b/kafka-ui-react-app/src/components/Topics/Topic/Topic.tsx
@@ -59,7 +59,7 @@ const Topic: React.FC = () => {
 
   const deleteTopicHandler = async () => {
     await deleteTopic.mutateAsync(topicName);
-    navigate('../..');
+    navigate(clusterTopicsPath(clusterName));
   };
 
   React.useEffect(() => {

--- a/kafka-ui-react-app/src/components/Topics/Topic/__test__/Topic.spec.tsx
+++ b/kafka-ui-react-app/src/components/Topics/Topic/__test__/Topic.spec.tsx
@@ -10,6 +10,7 @@ import {
   clusterTopicMessagesPath,
   clusterTopicPath,
   clusterTopicSettingsPath,
+  clusterTopicsPath,
   clusterTopicStatisticsPath,
   getNonExactPath,
 } from 'lib/paths';
@@ -179,7 +180,9 @@ describe('Details', () => {
         name: 'Confirm',
       });
       await userEvent.click(submitDeleteButton);
-      expect(mockNavigate).toHaveBeenCalledWith('../..');
+      expect(mockNavigate).toHaveBeenCalledWith(
+        clusterTopicsPath(mockClusterName)
+      );
     });
 
     it('shows a confirmation popup on deleting topic messages', async () => {


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)


<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)
Implement system redirects to topics after topic delete 
**Is there anything you'd like reviewers to focus on?**


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (please, describe, if necessary)
- [x] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/provectus/kafka-ui/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/provectus/kafka-ui/blob/master/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**
