### PR TITLE
fix missing q when filtering

### DIFF
--- a/kafka-ui-react-app/src/components/Topics/Topic/Messages/Filters/Filters.tsx
+++ b/kafka-ui-react-app/src/components/Topics/Topic/Messages/Filters/Filters.tsx
@@ -204,7 +204,7 @@ const Filters: React.FC<FiltersProps> = ({
       q:
         queryType === MessageFilterType.GROOVY_SCRIPT
           ? activeFilter.code
-          : query,
+          : searchParams.get('q') || '',
       filterQueryType: queryType,
       attempt: nextAttempt,
       limit: PER_PAGE,


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)


<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)
- as-is
After changing other filter type(here, seekDirection), search `parameter q` is missing even existing in the box.
So for correct search result, I have to retype the value.
I guess it occurs after https://github.com/provectus/kafka-ui/pull/2462

https://user-images.githubusercontent.com/50516754/233320405-cf687038-28b9-4f8b-9e55-c7ae601a2091.mov


- changes

`paramter q` still appears with other filters
https://user-images.githubusercontent.com/50516754/233320626-782b4d20-15b4-45db-a91d-919dca02e880.mov


**Is there anything you'd like reviewers to focus on?**


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (please, describe, if necessary)
- [] Unit checks
- [x] Integration checks
- [] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/provectus/kafka-ui/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/provectus/kafka-ui/blob/master/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**

