### PR TITLE
docs: fix configmap parameter name in quick-start.md

### DIFF
--- a/configuration/helm-charts/quick-start.md
+++ b/configuration/helm-charts/quick-start.md
@@ -44,7 +44,7 @@ Create config map
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: kafka-ui-existing-configmap-as-a-configfile
+  name: kafka-ui-configmap
 data:
   config.yml: |-
     kafka:
@@ -63,7 +63,7 @@ This ConfigMap will be mounted to the Pod
 
 Install by executing the command
 
-> helm install helm-release-name charts/kafka-ui --set yamlApplicationConfigConfigMap.name="kafka-ui-config",yamlApplicationConfigConfigMap.keyName="config.yml"
+> helm install helm-release-name charts/kafka-ui --set yamlApplicationConfigConfigMap.name="kafka-ui-configmap",yamlApplicationConfigConfigMap.keyName="config.yml"
 
 #### Passing environment variables as ConfigMap
 


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)


<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)

- Rectify the incorrect yamlApplicationConfigConfigMap.name parameter value in the Helm Quick-Start documentation.
- The current configuration map name is excessively lengthy, so I fix it.

**Is there anything you'd like reviewers to focus on?**

- Naming of pre-existing configmap

**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (please, describe, if necessary)
- [ ] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/provectus/kafka-ui/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/provectus/kafka-ui/blob/master/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**
