### PR TITLE
Set preceding/succeeding pathType to range scope

### DIFF
--- a/charts/kafka-ui/templates/ingress.yaml
+++ b/charts/kafka-ui/templates/ingress.yaml
@@ -35,7 +35,7 @@ spec:
 {{- if and ($.Capabilities.APIVersions.Has "networking.k8s.io/v1") $isHigher1p19 -}}
           {{- range .Values.ingress.precedingPaths }}
           - path: {{ .path }}
-            pathType: {{ .Values.ingress.pathType }}
+            pathType: {{ .pathType }}
             backend:
               service:
                 name: {{ .serviceName }}
@@ -53,7 +53,7 @@ spec:
 {{- end }}
           {{- range .Values.ingress.succeedingPaths }}
           - path: {{ .path }}
-            pathType: {{ .Values.ingress.pathType }}
+            pathType: {{ .pathType }}
             backend:
               service:
                 name: {{ .serviceName }}


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [x] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)
Yes, but I'm not sure if anyone was using this correctly to begin with. See explanation below.

<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)
#3259 introduced the ability to set the prefixType, however the preceedingPaths and succeedingPaths reference a variable that is out of scope of the range.

```
          {{- range .Values.ingress.succeedingPaths }}
          - path: {{ .path }}
            pathType: {{ .Values.ingress.pathType }}
            backend:
              service:
                name: {{ .serviceName }}
                port:
                  number: {{ .servicePort }}
          {{- end }}
```

In the range section, `.Values.ingress.pathType` refers to `.Values.ingress.succeedingPaths[n].Values.ingress.pathType` which I don't think was the intention.

This change switches it to `.pathType`, which refers to `.Values.ingress.succeedingPaths[n].pathType`, similar to `path`, `serviceName`, and `servicePort` variables.

Before this change in order to get the pathType set you'd need to configure the preceding/succeeding path to:

```
    succeedingPaths:
      - path: "/kafkaui/"
        Values:
          ingress:
            pathType: Prefix
        serviceName: kafkaui-service
        servicePort: 80
```
After this change it would reference be set by:

```
    succeedingPaths:
      - path: "/kafkaui/"
        pathType: Prefix
        serviceName: kafkaui-service
        servicePort: 80
```

**Is there anything you'd like reviewers to focus on?**


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (please, describe, if necessary)
- [ ] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

Set new schema value and verified helm deployment worked.

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/provectus/kafka-ui/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/provectus/kafka-ui/blob/master/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**
Meet my dog Lupin!

![IMG_0830](https://github.com/provectus/kafka-ui/assets/60897865/7239f107-38ee-40e0-9a0a-57c2c9a129de)
