### PR TITLE
Fixed Messages Paging

### DIFF
--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/controller/MessagesController.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/controller/MessagesController.java
@@ -73,6 +73,7 @@ public class MessagesController extends AbstractController implements MessagesAp
                                                                            SeekTypeDTO seekType,
                                                                            List<String> seekTo,
                                                                            Integer limit,
+                                                                           Integer page,
                                                                            String q,
                                                                            MessageFilterTypeDTO filterQueryType,
                                                                            SeekDirectionDTO seekDirection,
@@ -85,6 +86,7 @@ public class MessagesController extends AbstractController implements MessagesAp
         .topicActions(MESSAGES_READ)
         .build());
 
+    page = page != null ? page : 0;
     seekType = seekType != null ? seekType : SeekTypeDTO.BEGINNING;
     seekDirection = seekDirection != null ? seekDirection : SeekDirectionDTO.FORWARD;
     filterQueryType = filterQueryType != null ? filterQueryType : MessageFilterTypeDTO.STRING_CONTAINS;
@@ -98,7 +100,7 @@ public class MessagesController extends AbstractController implements MessagesAp
         ResponseEntity.ok(
             messagesService.loadMessages(
                 getCluster(clusterName), topicName, positions, q, filterQueryType,
-                limit, seekDirection, keySerde, valueSerde)
+                limit, page, seekDirection, keySerde, valueSerde)
         )
     );
 

--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/emitter/AbstractEmitter.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/emitter/AbstractEmitter.java
@@ -59,4 +59,8 @@ public abstract class AbstractEmitter {
     messagesProcessing.sendFinishEvent(sink);
     sink.complete();
   }
+
+  protected Integer getPageOffset() {
+    return messagesProcessing.getPageOffset();
+  }
 }

--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/emitter/BackwardRecordEmitter.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/emitter/BackwardRecordEmitter.java
@@ -57,7 +57,9 @@ public class BackwardRecordEmitter
             return; //fast return in case of sink cancellation
           }
           long beginOffset = seekOperations.getBeginOffsets().get(tp);
-          long readFromOffset = Math.max(beginOffset, readToOffset - msgsToPollPerPartition);
+          long readFromOffset = Math.max(beginOffset, readToOffset - msgsToPollPerPartition - this.getPageOffset());
+          readToOffset = readToOffset - this.getPageOffset();
+
 
           partitionPollIteration(tp, readFromOffset, readToOffset, consumer, sink)
               .forEach(r -> sendMessage(sink, r));

--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/emitter/ForwardRecordEmitter.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/emitter/ForwardRecordEmitter.java
@@ -37,6 +37,10 @@ public class ForwardRecordEmitter
       var seekOperations = SeekOperations.create(consumer, position);
       seekOperations.assignAndSeekNonEmptyPartitions();
 
+      seekOperations.getOffsetsForSeek().forEach((p, o) -> {
+        consumer.seek(p, o + getPageOffset());
+      });
+
       EmptyPollsCounter emptyPolls = pollingSettings.createEmptyPollsCounter();
       while (!sink.isCancelled()
           && !sendLimitReached()

--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/emitter/MessagesProcessing.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/emitter/MessagesProcessing.java
@@ -23,16 +23,24 @@ public class MessagesProcessing {
   private final Predicate<TopicMessageDTO> filter;
   private final @Nullable Integer limit;
 
+  private final @Nullable Integer page;
+
   public MessagesProcessing(ConsumerRecordDeserializer deserializer,
                             Predicate<TopicMessageDTO> filter,
-                            @Nullable Integer limit) {
+                            @Nullable Integer limit,
+                            @Nullable Integer page) {
     this.deserializer = deserializer;
     this.filter = filter;
     this.limit = limit;
+    this.page = page;
   }
 
   boolean limitReached() {
     return limit != null && sentMessages >= limit;
+  }
+
+  Integer getPageOffset() {
+    return this.limit * this.page;
   }
 
   void sendMsg(FluxSink<TopicMessageEventDTO> sink, ConsumerRecord<Bytes, Bytes> rec) {

--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/service/MessagesService.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/service/MessagesService.java
@@ -160,6 +160,7 @@ public class MessagesService {
                                                  @Nullable String query,
                                                  MessageFilterTypeDTO filterQueryType,
                                                  @Nullable Integer pageSize,
+                                                 Integer page,
                                                  SeekDirectionDTO seekDirection,
                                                  @Nullable String keySerde,
                                                  @Nullable String valueSerde) {
@@ -167,7 +168,8 @@ public class MessagesService {
         .flux()
         .publishOn(Schedulers.boundedElastic())
         .flatMap(td -> loadMessagesImpl(cluster, topic, consumerPosition, query,
-            filterQueryType, fixPageSize(pageSize), seekDirection, keySerde, valueSerde));
+            filterQueryType, fixPageSize(pageSize), page,
+            seekDirection, keySerde, valueSerde));
   }
 
   private int fixPageSize(@Nullable Integer pageSize) {
@@ -182,6 +184,7 @@ public class MessagesService {
                                                       @Nullable String query,
                                                       MessageFilterTypeDTO filterQueryType,
                                                       int limit,
+                                                      int page,
                                                       SeekDirectionDTO seekDirection,
                                                       @Nullable String keySerde,
                                                       @Nullable String valueSerde) {
@@ -191,7 +194,8 @@ public class MessagesService {
     var processing = new MessagesProcessing(
         deserializationService.deserializerFor(cluster, topic, keySerde, valueSerde),
         getMsgFilter(query, filterQueryType),
-        seekDirection == SeekDirectionDTO.TAILING ? null : limit
+        seekDirection == SeekDirectionDTO.TAILING ? null : limit,
+        page
     );
 
     if (seekDirection.equals(SeekDirectionDTO.FORWARD)) {

--- a/kafka-ui-api/src/test/java/com/provectus/kafka/ui/emitter/TailingEmitterTest.java
+++ b/kafka-ui-api/src/test/java/com/provectus/kafka/ui/emitter/TailingEmitterTest.java
@@ -115,6 +115,7 @@ class TailingEmitterTest extends AbstractIntegrationTest {
             query,
             MessageFilterTypeDTO.STRING_CONTAINS,
             0,
+            0,
             SeekDirectionDTO.TAILING,
             "String",
             "String");

--- a/kafka-ui-api/src/test/java/com/provectus/kafka/ui/service/MessagesServiceTest.java
+++ b/kafka-ui-api/src/test/java/com/provectus/kafka/ui/service/MessagesServiceTest.java
@@ -55,7 +55,7 @@ class MessagesServiceTest extends AbstractIntegrationTest {
   @Test
   void loadMessagesReturnsExceptionWhenTopicNotFound() {
     StepVerifier.create(messagesService
-            .loadMessages(cluster, NON_EXISTING_TOPIC, null, null, null, 1, null, "String", "String"))
+            .loadMessages(cluster, NON_EXISTING_TOPIC, null, null, null, 1, 0, null, "String", "String"))
         .expectError(TopicNotFoundException.class)
         .verify();
   }
@@ -75,6 +75,7 @@ class MessagesServiceTest extends AbstractIntegrationTest {
           null,
           null,
           100,
+          0,
           SeekDirectionDTO.FORWARD,
           StringSerde.name(),
           StringSerde.name()

--- a/kafka-ui-api/src/test/java/com/provectus/kafka/ui/service/SendAndReadTests.java
+++ b/kafka-ui-api/src/test/java/com/provectus/kafka/ui/service/SendAndReadTests.java
@@ -508,6 +508,7 @@ public class SendAndReadTests extends AbstractIntegrationTest {
                 null,
                 null,
                 1,
+                0,
                 SeekDirectionDTO.FORWARD,
                 msgToSend.getKeySerde().get(),
                 msgToSend.getValueSerde().get()

--- a/kafka-ui-contract/src/main/resources/swagger/kafka-ui-api.yaml
+++ b/kafka-ui-contract/src/main/resources/swagger/kafka-ui-api.yaml
@@ -658,6 +658,10 @@ paths:
           in: query
           schema:
             type: integer
+        - name: page
+          in: query
+          schema:
+            type: integer
         - name: q
           in: query
           schema:


### PR DESCRIPTION
**What changes did you make?** (Give an overview)
I have fixed paging in messages as it was not working (described here: https://github.com/provectus/kafka-ui/issues/3129)
'page' query param was not sent to controller, acording to this parameter, i just move offset of the topic.

**Is there anything you'd like reviewers to focus on?**
Just check if it is ok :)


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
- [ ] No need to
- [x] Manually (please, describe, if necessary)
- [ ] Unit checks
- [ ] Integration checks
- [x] Covered by existing automation

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [ ] My changes generate no new warnings (e.g. Sonar is happy)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/provectus/kafka-ui/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/provectus/kafka-ui/blob/master/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**
![image](https://github.com/provectus/kafka-ui/assets/10706202/0b9309ba-b009-4f85-bd78-801ecc017c48)
