### PR TITLE
FE: Adding Schema (Value) and Schema (Key) tab to the Topic details view

### DIFF
--- a/kafka-ui-react-app/src/components/Topics/Topic/Schema/Schema.styled.tsx
+++ b/kafka-ui-react-app/src/components/Topics/Topic/Schema/Schema.styled.tsx
@@ -1,0 +1,22 @@
+import styled from 'styled-components';
+
+export const Wrapper = styled.div`
+  width: 100%;
+  background-color: ${({ theme }) => theme.layout.stuffColor};
+  padding: 16px;
+  display: flex;
+  justify-content: center;
+  align-items: stretch;
+  gap: 2px;
+  max-height: 700px;
+
+  & > * {
+    background-color: ${({ theme }) => theme.default.backgroundColor};
+    padding: 24px;
+    overflow-y: scroll;
+  }
+
+  p {
+    color: ${({ theme }) => theme.schema.backgroundColor.p};
+  }
+`;

--- a/kafka-ui-react-app/src/components/Topics/Topic/Schema/Schema.tsx
+++ b/kafka-ui-react-app/src/components/Topics/Topic/Schema/Schema.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import useAppParams from 'lib/hooks/useAppParams';
+import { RouteParamsClusterTopic } from 'lib/paths';
+import { useAppDispatch, useAppSelector } from 'lib/hooks/redux';
+import { resetLoaderById } from 'redux/reducers/loader/loaderSlice';
+import {
+  fetchLatestSchema,
+  getSchemaLatest,
+  getAreSchemaLatestFulfilled,
+  getAreSchemaLatestRejected,
+  SCHEMA_LATEST_FETCH_ACTION,
+} from 'redux/reducers/schemas/schemasSlice';
+import LatestVersionItem from '../../../Schemas/Details/LatestVersion/LatestVersionItem';
+import PageLoader from 'components/common/PageLoader/PageLoader';
+
+import * as S from './Schema.styled';
+
+export enum SchemaType {
+  Value,
+  Key,
+}
+
+interface SchemaProps {
+  type: SchemaType;
+}
+
+export const Schema: React.FC<SchemaProps> = ({ type }) => {
+  const dispatch = useAppDispatch();
+  const { clusterName, topicName } = useAppParams<RouteParamsClusterTopic>();
+  const subject = topicName + '-' + SchemaType[type].toLowerCase();
+  React.useEffect(() => {
+    dispatch(fetchLatestSchema({ clusterName, subject }));
+    return () => {
+      dispatch(resetLoaderById(SCHEMA_LATEST_FETCH_ACTION));
+    };
+  }, [clusterName, dispatch, subject]);
+
+  const schema = useAppSelector(getSchemaLatest);
+  const isFetched = useAppSelector(getAreSchemaLatestFulfilled);
+  const isRejected = useAppSelector(getAreSchemaLatestRejected);
+
+  if (!isFetched && !isRejected) {
+    return <PageLoader />;
+  }
+
+  if (isRejected || !schema) {
+    return (
+      <S.Wrapper>
+        <p>
+          No {SchemaType[type].toLowerCase()} schema available for {topicName} at {clusterName}
+        </p>
+      </S.Wrapper>
+    );
+  }
+
+  return <LatestVersionItem schema={schema} />;
+};

--- a/kafka-ui-react-app/src/components/Topics/Topic/Topic.tsx
+++ b/kafka-ui-react-app/src/components/Topics/Topic/Topic.tsx
@@ -4,6 +4,8 @@ import {
   clusterTopicConsumerGroupsRelativePath,
   clusterTopicEditRelativePath,
   clusterTopicMessagesRelativePath,
+  clusterTopicSchemaValueRelativePath,
+  clusterTopicSchemaKeyRelativePath,
   clusterTopicSettingsRelativePath,
   clusterTopicsPath,
   clusterTopicStatisticsRelativePath,
@@ -33,6 +35,7 @@ import SlidingSidebar from 'components/common/SlidingSidebar';
 import useBoolean from 'lib/hooks/useBoolean';
 
 import Messages from './Messages/Messages';
+import { Schema, SchemaType } from './Schema/Schema';
 import Overview from './Overview/Overview';
 import Settings from './Settings/Settings';
 import TopicConsumerGroups from './ConsumerGroups/TopicConsumerGroups';
@@ -54,7 +57,7 @@ const Topic: React.FC = () => {
   const recreateTopic = useRecreateTopic({ clusterName, topicName });
   const { data } = useTopicDetails({ clusterName, topicName });
 
-  const { isReadOnly, isTopicDeletionAllowed } =
+  const { isReadOnly, isTopicDeletionAllowed, hasSchemaRegistryConfigured } =
     React.useContext(ClusterContext);
 
   const deleteTopicHandler = async () => {
@@ -189,6 +192,21 @@ const Topic: React.FC = () => {
         >
           Messages
         </ActionNavLink>
+        { hasSchemaRegistryConfigured ?
+        <>
+          <NavLink
+            to={clusterTopicSchemaValueRelativePath}
+            className={({ isActive }) => (isActive ? 'is-active' : '')}
+          >
+            Schema (Value)
+          </NavLink>
+          <NavLink
+            to={clusterTopicSchemaKeyRelativePath}
+            className={({ isActive }) => (isActive ? 'is-active' : '')}
+          >
+            Schema (Key)
+          </NavLink>
+        </> : null }
         <NavLink
           to={clusterTopicConsumerGroupsRelativePath}
           className={({ isActive }) => (isActive ? 'is-active' : '')}
@@ -215,6 +233,18 @@ const Topic: React.FC = () => {
             path={clusterTopicMessagesRelativePath}
             element={<Messages />}
           />
+          { hasSchemaRegistryConfigured ?
+          <>
+            <Route
+              path={clusterTopicSchemaValueRelativePath}
+              element={<Schema type={SchemaType.Value} />}
+            />
+            <Route
+              path={clusterTopicSchemaKeyRelativePath}
+              element={<Schema type={SchemaType.Key} />}
+            />
+          </>
+          : null }
           <Route
             path={clusterTopicSettingsRelativePath}
             element={<Settings />}

--- a/kafka-ui-react-app/src/lib/paths.ts
+++ b/kafka-ui-react-app/src/lib/paths.ts
@@ -144,6 +144,8 @@ export const clusterTopicCopyPath = (
 // Topics topic
 export const clusterTopicSettingsRelativePath = 'settings';
 export const clusterTopicMessagesRelativePath = 'messages';
+export const clusterTopicSchemaValueRelativePath = 'schema-value';
+export const clusterTopicSchemaKeyRelativePath = 'schema-key';
 export const clusterTopicConsumerGroupsRelativePath = 'consumer-groups';
 export const clusterTopicStatisticsRelativePath = 'statistics';
 export const clusterTopicEditRelativePath = 'edit';
@@ -167,6 +169,22 @@ export const clusterTopicMessagesPath = (
     clusterName,
     topicName
   )}/${clusterTopicMessagesRelativePath}`;
+export const clusterTopicSchemaValuePath = (
+  clusterName: ClusterName = RouteParams.clusterName,
+  topicName: TopicName = RouteParams.topicName
+) =>
+  `${clusterTopicPath(
+    clusterName,
+    topicName
+  )}/${clusterTopicSchemaValueRelativePath}`;
+export const clusterTopicSchemaKeyPath = (
+  clusterName: ClusterName = RouteParams.clusterName,
+  topicName: TopicName = RouteParams.topicName
+) =>
+  `${clusterTopicPath(
+    clusterName,
+    topicName
+  )}/${clusterTopicSchemaKeyRelativePath}`;
 export const clusterTopicEditPath = (
   clusterName: ClusterName = RouteParams.clusterName,
   topicName: TopicName = RouteParams.topicName


### PR DESCRIPTION
The two tabs will allow for quick access to the schemas for the messages produced to the topic.

Meaningful debug message is shown if schema is not available for either topic key or topic value and hasSchemaRegistryConfigured is true.

Tabs are not shown if hasSchemaRegistryConfigured is not true.

**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (please, describe, if necessary)
- [ ] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

![tiny-white-kitten-873941684-2000-0bac130389984aba9751de5e5e50d25f](https://github.com/provectus/kafka-ui/assets/3225795/583b925e-62c0-4610-904e-e765d0e242f1)
