### PR TITLE
BE: Respect system proxy settings in WebClient

### DIFF
--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/util/WebClientConfigurator.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/util/WebClientConfigurator.java
@@ -28,13 +28,12 @@ import reactor.netty.http.client.HttpClient;
 public class WebClientConfigurator {
 
   private final WebClient.Builder builder = WebClient.builder();
+  private HttpClient httpClient = HttpClient
+      .create()
+      .proxyWithSystemProperties();
 
   public WebClientConfigurator() {
     configureObjectMapper(defaultOM());
-    var httpClient = HttpClient
-        .create()
-        .proxyWithSystemProperties();
-    builder.clientConnector(new ReactorClientHttpConnector(httpClient));
   }
 
   private static ObjectMapper defaultOM() {
@@ -94,12 +93,7 @@ public class WebClientConfigurator {
     // Create webclient
     SslContext context = contextBuilder.build();
 
-    var httpClient = HttpClient
-        .create()
-        .secure(t -> t.sslContext(context))
-        .proxyWithSystemProperties();
-
-    builder.clientConnector(new ReactorClientHttpConnector(httpClient));
+    httpClient = httpClient.secure(t -> t.sslContext(context));
     return this;
   }
 
@@ -135,6 +129,6 @@ public class WebClientConfigurator {
   }
 
   public WebClient build() {
-    return builder.build();
+    return builder.clientConnector(new ReactorClientHttpConnector(httpClient)).build();
   }
 }

--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/util/WebClientConfigurator.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/util/WebClientConfigurator.java
@@ -31,6 +31,10 @@ public class WebClientConfigurator {
 
   public WebClientConfigurator() {
     configureObjectMapper(defaultOM());
+    var httpClient = HttpClient
+        .create()
+        .proxyWithSystemProperties();
+    builder.clientConnector(new ReactorClientHttpConnector(httpClient));
   }
 
   private static ObjectMapper defaultOM() {


### PR DESCRIPTION
HTTP(S) proxy settings are applied only in some specific cases when `configureSsl` is called with some non-null params. They should be always used.

`GithubReleaseInfo` is not executed properly in our environment.

<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)


<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)

**Is there anything you'd like reviewers to focus on?**


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (please, describe, if necessary)

Checked this branch on our production env:
<img width="771" alt="Screenshot 2023-07-18 at 10 33 32" src="https://github.com/provectus/kafka-ui/assets/3982146/77762fb4-7775-4351-ad1e-7442391cdb58">


- [ ] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [ ] My changes generate no new warnings (e.g. Sonar is happy)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/provectus/kafka-ui/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/provectus/kafka-ui/blob/master/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**
