### PR TITLE
Hex serde initialisation fix

### DIFF
--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/serdes/builtin/HexSerde.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/serdes/builtin/HexSerde.java
@@ -17,11 +17,20 @@ public class HexSerde implements BuiltInSerde {
   }
 
   @Override
+  public void autoConfigure(PropertyResolver kafkaClusterProperties, PropertyResolver globalProperties) {
+    configure(" ", true);
+  }
+
+  @Override
   public void configure(PropertyResolver serdeProperties,
                         PropertyResolver kafkaClusterProperties,
                         PropertyResolver globalProperties) {
     String delim = serdeProperties.getProperty("delimiter", String.class).orElse(" ");
     boolean uppercase = serdeProperties.getProperty("uppercase", Boolean.class).orElse(true);
+    configure(delim, uppercase);
+  }
+
+  private void configure(String delim, boolean uppercase) {
     deserializeHexFormat = HexFormat.ofDelimiter(delim);
     if (uppercase) {
       deserializeHexFormat = deserializeHexFormat.withUpperCase();

--- a/kafka-ui-api/src/test/java/com/provectus/kafka/ui/serdes/builtin/HexSerdeTest.java
+++ b/kafka-ui-api/src/test/java/com/provectus/kafka/ui/serdes/builtin/HexSerdeTest.java
@@ -16,16 +16,12 @@ public class HexSerdeTest {
   private static final byte[] TEST_BYTES = "hello world".getBytes();
   private static final String TEST_BYTES_HEX_ENCODED = "68 65 6C 6C 6F 20 77 6F 72 6C 64";
 
-  private Serde hexSerde;
+  private HexSerde hexSerde;
 
   @BeforeEach
   void init() {
     hexSerde = new HexSerde();
-    hexSerde.configure(
-        PropertyResolverImpl.empty(),
-        PropertyResolverImpl.empty(),
-        PropertyResolverImpl.empty()
-    );
+    hexSerde.autoConfigure(PropertyResolverImpl.empty(), PropertyResolverImpl.empty());
   }
 
 


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)

Implementing autoConfigure for HexSerde

<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)

**Is there anything you'd like reviewers to focus on?**


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (please, describe, if necessary)
- [ ] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/provectus/kafka-ui/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/provectus/kafka-ui/blob/master/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**
