### PR TITLE
FE: fix KC action DELETE to EDIT

### DIFF
--- a/kafka-ui-react-app/src/components/Connect/Details/Actions/Actions.tsx
+++ b/kafka-ui-react-app/src/components/Connect/Details/Actions/Actions.tsx
@@ -138,7 +138,7 @@ const Actions: React.FC = () => {
           danger
           permission={{
             resource: ResourceType.CONNECT,
-            action: Action.DELETE,
+            action: Action.EDIT,
             value: routerProps.connectorName,
           }}
         >


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)


<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)
<img width="1309" alt="스크린샷 2023-08-30 오후 5 27 53" src="https://github.com/provectus/kafka-ui/assets/50516754/3ee79f1b-7833-4cc7-97fb-b740ff16bb6f">
in spite of all permission for KC(Kafka Connect), i cannot delete connect KC in each page. (image)
because the component has 'DELETE' action which is not in KC action list now, so i changed it to 'EDIT'

i also got the next plan for RBAC https://github.com/provectus/kafka-ui/issues/4170,  but i think this is a issue that needs to be fixed for current use
thank you for your review. 😃 


**Is there anything you'd like reviewers to focus on?**


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [X] Manually (please, describe, if necessary)
- [ ] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [X] My changes generate no new warnings (e.g. Sonar is happy)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged

Check out [Contributing](https://github.com/provectus/kafka-ui/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/provectus/kafka-ui/blob/master/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**
