### PR TITLE
BE: Add logout with query parameters to generic OAuth provider

### DIFF
--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/config/auth/OAuthSecurityConfig.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/config/auth/OAuthSecurityConfig.java
@@ -1,6 +1,6 @@
 package com.provectus.kafka.ui.config.auth;
 
-import com.provectus.kafka.ui.config.auth.logout.OAuthLogoutSuccessHandler;
+import com.provectus.kafka.ui.config.auth.logout.OAuth2ServerLogoutSuccessHandler;
 import com.provectus.kafka.ui.service.rbac.AccessControlService;
 import com.provectus.kafka.ui.service.rbac.extractor.ProviderAuthorityExtractor;
 import java.util.ArrayList;
@@ -47,7 +47,7 @@ public class OAuthSecurityConfig extends AbstractAuthSecurityConfig {
   private final OAuthProperties properties;
 
   @Bean
-  public SecurityWebFilterChain configure(ServerHttpSecurity http, OAuthLogoutSuccessHandler logoutHandler) {
+  public SecurityWebFilterChain configure(ServerHttpSecurity http, OAuth2ServerLogoutSuccessHandler logoutHandler) {
     log.info("Configuring OAUTH2 authentication.");
 
     return http.authorizeExchange(spec -> spec

--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/config/auth/condition/OAuthCondition.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/config/auth/condition/OAuthCondition.java
@@ -1,0 +1,14 @@
+package com.provectus.kafka.ui.config.auth.condition;
+
+import com.provectus.kafka.ui.service.rbac.AbstractProviderCondition;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+public class OAuthCondition extends AbstractProviderCondition implements Condition {
+  @Override
+  public boolean matches(final ConditionContext context, final @NotNull AnnotatedTypeMetadata metadata) {
+    return getRegisteredProvidersTypes(context.getEnvironment()).stream().anyMatch(a -> a.equalsIgnoreCase("oauth"));
+  }
+}

--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/config/auth/logout/CognitoLogoutSuccessHandler.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/config/auth/logout/CognitoLogoutSuccessHandler.java
@@ -4,60 +4,38 @@ import com.provectus.kafka.ui.config.auth.OAuthProperties;
 import com.provectus.kafka.ui.config.auth.condition.CognitoCondition;
 import com.provectus.kafka.ui.model.rbac.provider.Provider;
 import java.net.URI;
-import java.nio.charset.StandardCharsets;
+import java.util.Map;
 import org.springframework.context.annotation.Conditional;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.server.reactive.ServerHttpResponse;
-import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.web.server.WebFilterExchange;
-import org.springframework.security.web.util.UrlUtils;
 import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
-import org.springframework.web.server.WebSession;
+import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.web.util.UriComponents;
-import org.springframework.web.util.UriComponentsBuilder;
-import reactor.core.publisher.Mono;
 
 @Component
 @Conditional(CognitoCondition.class)
-public class CognitoLogoutSuccessHandler implements LogoutSuccessHandler {
+public class CognitoLogoutSuccessHandler extends QueryParamsLogoutSuccessHandler {
 
   @Override
-  public boolean isApplicable(String provider) {
-    return Provider.Name.COGNITO.equalsIgnoreCase(provider);
+  public boolean isApplicable(String provider, Map<String, String> customParams) {
+    return Provider.Name.COGNITO.equalsIgnoreCase(customParams.getOrDefault("type", null));
   }
 
   @Override
-  public Mono<Void> handle(WebFilterExchange exchange, Authentication authentication,
-                           OAuthProperties.OAuth2Provider provider) {
-    final ServerHttpResponse response = exchange.getExchange().getResponse();
-    response.setStatusCode(HttpStatus.FOUND);
-
-    final var requestUri = exchange.getExchange().getRequest().getURI();
-
-    final var fullUrl = UrlUtils.buildFullRequestUrl(requestUri.getScheme(),
-        requestUri.getHost(), requestUri.getPort(),
-        requestUri.getPath(), requestUri.getQuery());
-
-    final UriComponents baseUrl = UriComponentsBuilder
-        .fromHttpUrl(fullUrl)
-        .replacePath("/")
-        .replaceQuery(null)
-        .fragment(null)
-        .build();
+  protected URI buildRedirect(WebFilterExchange exchange, UriComponents baseUrl,
+                              OAuthProperties.OAuth2Provider provider, ClientRegistration clientRegistration) {
 
     Assert.isTrue(provider.getCustomParams().containsKey("logoutUrl"),
         "Custom params should contain 'logoutUrl'");
-    final var uri = UriComponentsBuilder
-        .fromUri(URI.create(provider.getCustomParams().get("logoutUrl")))
-        .queryParam("client_id", provider.getClientId())
-        .queryParam("logout_uri", baseUrl)
-        .encode(StandardCharsets.UTF_8)
-        .build()
-        .toUri();
 
-    response.getHeaders().setLocation(uri);
-    return exchange.getExchange().getSession().flatMap(WebSession::invalidate);
+    URI logoutUrl = URI.create(provider.getCustomParams().get("logoutUrl"));
+
+    var params = new LinkedMultiValueMap<String, String>();
+    params.add("client_id", provider.getClientId());
+    params.add("logout_uri", baseUrl.toString());
+
+    return createRedirectUrl(logoutUrl, params);
   }
 
 }

--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/config/auth/logout/LogoutSuccessHandler.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/config/auth/logout/LogoutSuccessHandler.java
@@ -1,15 +1,17 @@
 package com.provectus.kafka.ui.config.auth.logout;
 
 import com.provectus.kafka.ui.config.auth.OAuthProperties;
+import java.util.Map;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.web.server.WebFilterExchange;
 import reactor.core.publisher.Mono;
 
 public interface LogoutSuccessHandler {
 
-  boolean isApplicable(final String provider);
+  boolean isApplicable(final String provider, final Map<String, String> customParams);
 
   Mono<Void> handle(final WebFilterExchange exchange,
                     final Authentication authentication,
-                    final OAuthProperties.OAuth2Provider provider);
+                    final OAuthProperties.OAuth2Provider provider, ClientRegistration clientRegistration);
 }

--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/config/auth/logout/OAuth2ServerLogoutSuccessHandler.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/config/auth/logout/OAuth2ServerLogoutSuccessHandler.java
@@ -1,0 +1,56 @@
+package com.provectus.kafka.ui.config.auth.logout;
+
+import com.provectus.kafka.ui.config.auth.OAuthProperties;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.client.registration.ReactiveClientRegistrationRepository;
+import org.springframework.security.web.server.WebFilterExchange;
+import org.springframework.security.web.server.authentication.logout.ServerLogoutSuccessHandler;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+@Component
+@ConditionalOnProperty(value = "auth.type", havingValue = "OAUTH2")
+public class OAuth2ServerLogoutSuccessHandler implements ServerLogoutSuccessHandler {
+  private final OAuthProperties properties;
+  private final List<LogoutSuccessHandler> logoutSuccessHandlers;
+  private final ServerLogoutSuccessHandler defaultOidcLogoutHandler;
+  private final ReactiveClientRegistrationRepository clientRegistrationRegistry;
+
+  public OAuth2ServerLogoutSuccessHandler(final OAuthProperties properties,
+        final List<LogoutSuccessHandler> logoutSuccessHandlers,
+        final @Qualifier("defaultOidcLogoutHandler") ServerLogoutSuccessHandler handler,
+        final ReactiveClientRegistrationRepository clientRegistrationRegistry) {
+    this.properties = properties;
+    this.logoutSuccessHandlers = logoutSuccessHandlers;
+    this.defaultOidcLogoutHandler = handler;
+    this.clientRegistrationRegistry = clientRegistrationRegistry;
+  }
+
+  @Override
+  public Mono<Void> onLogoutSuccess(final WebFilterExchange exchange,
+                                    final Authentication authentication) {
+    final OAuth2AuthenticationToken oauthToken = (OAuth2AuthenticationToken) authentication;
+    final String providerId = oauthToken.getAuthorizedClientRegistrationId();
+    final OAuthProperties.OAuth2Provider oAuth2Provider = properties.getClient().get(providerId);
+    final String provider = oAuth2Provider.getProvider();
+    final Map<String, String> customParams = oAuth2Provider.getCustomParams();
+    return clientRegistrationRegistry
+        .findByRegistrationId(providerId)
+        .flatMap((clientRegistration) -> getLogoutHandler(provider, customParams)
+            .map(handler -> handler.handle(exchange, authentication, oAuth2Provider, clientRegistration))
+            .orElseGet(() -> defaultOidcLogoutHandler.onLogoutSuccess(exchange, authentication)));
+  }
+
+  private Optional<LogoutSuccessHandler> getLogoutHandler(final String provider,
+                                                          final Map<String, String> customParams) {
+    return logoutSuccessHandlers.stream()
+        .filter(h -> h.isApplicable(provider, customParams))
+        .findFirst();
+  }
+}

--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/config/auth/logout/OAuthLogoutSuccessHandler.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/config/auth/logout/OAuthLogoutSuccessHandler.java
@@ -1,46 +1,106 @@
 package com.provectus.kafka.ui.config.auth.logout;
 
 import com.provectus.kafka.ui.config.auth.OAuthProperties;
-import java.util.List;
-import java.util.Optional;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import com.provectus.kafka.ui.config.auth.condition.OAuthCondition;
+import com.provectus.kafka.ui.model.rbac.provider.Provider;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Set;
+import lombok.Getter;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.web.server.WebFilterExchange;
-import org.springframework.security.web.server.authentication.logout.ServerLogoutSuccessHandler;
 import org.springframework.stereotype.Component;
-import reactor.core.publisher.Mono;
+import org.springframework.util.Assert;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @Component
-@ConditionalOnProperty(value = "auth.type", havingValue = "OAUTH2")
-public class OAuthLogoutSuccessHandler implements ServerLogoutSuccessHandler {
-  private final OAuthProperties properties;
-  private final List<LogoutSuccessHandler> logoutSuccessHandlers;
-  private final ServerLogoutSuccessHandler defaultOidcLogoutHandler;
+@Conditional(OAuthCondition.class)
+public class OAuthLogoutSuccessHandler extends QueryParamsLogoutSuccessHandler {
 
-  public OAuthLogoutSuccessHandler(final OAuthProperties properties,
-                                   final List<LogoutSuccessHandler> logoutSuccessHandlers,
-                                   final @Qualifier("defaultOidcLogoutHandler") ServerLogoutSuccessHandler handler) {
-    this.properties = properties;
-    this.logoutSuccessHandlers = logoutSuccessHandlers;
-    this.defaultOidcLogoutHandler = handler;
+  @Getter
+  private enum Attributes {
+    CLIENT_ID_KEY("client-id-key"),
+    LOGOUT_URL("logout-url"),
+    REDIRECT_URL("redirect-url"),
+    REDIRECT_URL_KEY("redirect-url-key"),
+    REDIRECT_URL_STRIP_SLASH("redirect-url-strip-slash");
+
+    private final String value;
+
+    Attributes(String value) {
+      this.value = value;
+    }
+  }
+
+  private final Set<String> attributes = Set.of(Arrays.stream(Attributes.values()).map(Attributes::getValue)
+      .toArray(String[]::new));
+
+  private final Set<String> trueValues = Set.of("on", "true", "1", "yes");
+
+  @Override
+  public boolean isApplicable(String provider, Map<String, String> customParams) {
+    // oauth type is used for ACL too, so check if there is any of our attributes
+    return (Provider.Name.OAUTH.equalsIgnoreCase(customParams.getOrDefault("type", null))
+                || Provider.Name.OAUTH.equalsIgnoreCase(provider))
+        && attributes.stream().anyMatch(customParams::containsKey);
   }
 
   @Override
-  public Mono<Void> onLogoutSuccess(final WebFilterExchange exchange,
-                                    final Authentication authentication) {
-    final OAuth2AuthenticationToken oauthToken = (OAuth2AuthenticationToken) authentication;
-    final String providerId = oauthToken.getAuthorizedClientRegistrationId();
-    final OAuthProperties.OAuth2Provider oAuth2Provider = properties.getClient().get(providerId);
-    return getLogoutHandler(oAuth2Provider.getProvider())
-        .map(handler -> handler.handle(exchange, authentication, oAuth2Provider))
-        .orElseGet(() -> defaultOidcLogoutHandler.onLogoutSuccess(exchange, authentication));
+  protected URI buildRedirect(WebFilterExchange exchange, UriComponents baseUrl,
+                              OAuthProperties.OAuth2Provider provider, ClientRegistration clientRegistration) {
+    URI logoutUrl = null;
+
+    if (provider.getCustomParams().containsKey(Attributes.LOGOUT_URL.getValue())) {
+      logoutUrl = URI.create(provider.getCustomParams().get(Attributes.LOGOUT_URL.getValue()));
+    }
+
+    if (logoutUrl == null && clientRegistration != null) {
+      Object endSessionEndpoint = clientRegistration.getProviderDetails().getConfigurationMetadata()
+          .get("end_session_endpoint");
+      if (endSessionEndpoint != null) {
+        logoutUrl = URI.create(endSessionEndpoint.toString());
+      }
+    }
+
+    Assert.notNull(logoutUrl, "Cannot determine logout URL, custom params should contain 'logout-url'");
+
+    var params = new LinkedMultiValueMap<String, String>();
+
+    if (provider.getCustomParams().containsKey(Attributes.CLIENT_ID_KEY.getValue())) {
+      params.add(provider.getCustomParams().get(Attributes.CLIENT_ID_KEY.getValue()), provider.getClientId());
+    }
+
+
+    if (provider.getCustomParams().containsKey(Attributes.REDIRECT_URL_KEY.getValue())) {
+      String redirectUrl = provider.getCustomParams().getOrDefault(Attributes.REDIRECT_URL.getValue(),
+                                                                   baseUrl.toString());
+
+      if (provider.getCustomParams().containsKey(Attributes.REDIRECT_URL_STRIP_SLASH.getValue())) {
+        var stripSlashValue = String.valueOf(provider.getCustomParams()
+            .get(Attributes.REDIRECT_URL_STRIP_SLASH.getValue())).toLowerCase();
+
+        if (trueValues.contains(stripSlashValue)) {
+          redirectUrl = stripSlash(redirectUrl);
+        }
+      }
+
+      params.add(provider.getCustomParams().get(Attributes.REDIRECT_URL_KEY.getValue()), redirectUrl);
+    }
+
+    return createRedirectUrl(logoutUrl, params);
   }
 
-  private Optional<LogoutSuccessHandler> getLogoutHandler(final String provider) {
-    return logoutSuccessHandlers.stream()
-        .filter(h -> h.isApplicable(provider))
-        .findFirst();
+  private String stripSlash(String url) {
+    URI parsedUrl = URI.create(url);
+    if (parsedUrl.isAbsolute() && parsedUrl.getPath().endsWith("/")) {
+      return UriComponentsBuilder.fromUri(parsedUrl).replacePath(
+          parsedUrl.getPath().substring(0, parsedUrl.getPath().length() - 1)).build().toString();
+    } else {
+      return url;
+    }
   }
 }

--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/config/auth/logout/QueryParamsLogoutSuccessHandler.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/config/auth/logout/QueryParamsLogoutSuccessHandler.java
@@ -1,0 +1,54 @@
+package com.provectus.kafka.ui.config.auth.logout;
+
+import com.provectus.kafka.ui.config.auth.OAuthProperties;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.web.server.WebFilterExchange;
+import org.springframework.security.web.util.UrlUtils;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.server.WebSession;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
+import reactor.core.publisher.Mono;
+
+public abstract class QueryParamsLogoutSuccessHandler implements LogoutSuccessHandler {
+
+  @Override
+  public Mono<Void> handle(WebFilterExchange exchange, Authentication authentication,
+                           OAuthProperties.OAuth2Provider provider, ClientRegistration clientRegistration) {
+    final var request = exchange.getExchange().getRequest();
+    final var requestUri = request.getURI();
+    final var contextPath = request.getPath().contextPath().value();
+
+    final UriComponents baseUrl = UriComponentsBuilder
+        .fromUri(requestUri)
+        .replacePath(contextPath)
+        .replaceQuery(null)
+        .fragment(null)
+        .build();
+
+    final var redirectUrl = buildRedirect(exchange, baseUrl, provider, clientRegistration);
+
+    final ServerHttpResponse response = exchange.getExchange().getResponse();
+    response.setStatusCode(HttpStatus.FOUND);
+    response.getHeaders().setLocation(redirectUrl);
+    return exchange.getExchange().getSession().flatMap(WebSession::invalidate);
+  }
+
+  protected abstract URI buildRedirect(WebFilterExchange exchange, UriComponents baseUrl,
+                                       OAuthProperties.OAuth2Provider provider,
+                                       ClientRegistration clientRegistration);
+
+  protected URI createRedirectUrl(URI logoutUrl, MultiValueMap<String, String> params) {
+    return UriComponentsBuilder.fromUri(logoutUrl)
+        .encode(StandardCharsets.UTF_8)
+        .replaceQueryParams(params)
+        .fragment(null)
+        .build()
+        .toUri();
+  }
+}

--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/service/rbac/AbstractProviderCondition.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/service/rbac/AbstractProviderCondition.java
@@ -23,7 +23,7 @@ public abstract class AbstractProviderCondition {
         .map(OAuthProperties.OAuth2Provider::getCustomParams)
         .filter(Objects::nonNull)
         .filter(Predicate.not(Map::isEmpty))
-        .map(params -> params.get("type"))
+        .map(params -> params.getOrDefault("type", null))
         .filter(Objects::nonNull)
         .filter(StringUtils::isNotEmpty)
         .collect(Collectors.toSet());


### PR DESCRIPTION
The logout URL is taken from auto-detected endpoint from the provider's well known configuration address, but can be overridden by custom parameter `logout-url`. Query parameters are optional and are added only when the corresponding key is present. Default redirect URL is a base URL and can be overridden in custom parameters.

Also the final slash from the redirect URL can be removed when `redirect-url-strip-slash` is set to true/yes/on/1.

Example with all custom parameters:

```
custom-params:
  type: oauth
  logout-url: https://example.com/sso/logout
  client-id-key: clientId
  redirect-url-key: returnTo
  redirect-url: https://example.com/kafka-ui
  redirect-url-strip-slash: true
```

<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)


<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)

I generalized original Cognito logout code and created common ancestor. I added new OAuth logout handling, which is generic enough to handle Cognito logout too, but I kept Cognito for simplicity of
configuration.

**Is there anything you'd like reviewers to focus on?**

I changed the calculation of redirect URL after logout to have the context path. For normal installation there is no change in behaviour (context path is root - "/").

**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (please, describe, if necessary)
- [ ] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/provectus/kafka-ui/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/provectus/kafka-ui/blob/master/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**
![CatsKittyGIF](https://github.com/provectus/kafka-ui/assets/1260936/2fb2eec1-48db-4479-a818-c19346dd8843)
