### PR TITLE
closes Format numbers with locale #4036

### DIFF
--- a/kafka-ui-react-app/src/components/Topics/List/TopicTable.tsx
+++ b/kafka-ui-react-app/src/components/Topics/List/TopicTable.tsx
@@ -65,6 +65,7 @@ const TopicTable: React.FC = () => {
         accessorKey: 'replicationFactor',
         enableSorting: false,
       },
+    
       {
         header: 'Number of messages',
         accessorKey: 'partitions',
@@ -74,9 +75,10 @@ const TopicTable: React.FC = () => {
           if (partitions === undefined || partitions.length === 0) {
             return 0;
           }
-          return partitions.reduce((memo, { offsetMax, offsetMin }) => {
+          const totalMessages = partitions.reduce((memo, { offsetMax, offsetMin }) => {
             return memo + (offsetMax - offsetMin);
           }, 0);
+          return totalMessages.toLocaleString(); // Format with comma separators
         },
       },
       {


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)
changed format of number of messages 

<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)
modified ```return partitions.reduce((memo, { offsetMax, offsetMin }) => {
            return memo + (offsetMax - offsetMin);
          }, 0);```
with ``` const totalMessages = partitions.reduce((memo, { offsetMax, offsetMin }) => {
            return memo + (offsetMax - offsetMin);
          }, 0);
          return totalMessages.toLocaleString(); // Format with comma separators
        },```
**Is there anything you'd like reviewers to focus on?**


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [ ] Manually (please, describe, if necessary)
- [x] Unit checks
- [ ] Integration checks
- [] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/provectus/kafka-ui/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/provectus/kafka-ui/blob/master/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**
![image](https://github.com/provectus/kafka-ui/assets/97328833/14bcd9b8-3d02-43a6-a5cf-0e2ba5356d7b)
i have applied this test as shown went successfully 