### PR TITLE
Fix wrong broker tick, when broker ids starts with other than 0

### DIFF
--- a/kafka-ui-react-app/src/components/Brokers/BrokersList/BrokersList.tsx
+++ b/kafka-ui-react-app/src/components/Brokers/BrokersList/BrokersList.tsx
@@ -73,13 +73,14 @@ const BrokersList: React.FC = () => {
         header: 'Broker ID',
         accessorKey: 'brokerId',
         // eslint-disable-next-line react/no-unstable-nested-components
-        cell: ({ row: { id }, getValue }) => (
-          <S.RowCell>
+        cell: ({ getValue }) => {
+          const value = getValue<string | number>();
+          return (<S.RowCell>
             <LinkCell
-              value={`${getValue<string | number>()}`}
-              to={encodeURIComponent(`${getValue<string | number>()}`)}
+              value={value}
+              to={encodeURIComponent(value)}
             />
-            {id === String(activeControllers) && (
+            {value === activeControllers && (
               <Tooltip
                 value={<CheckMarkRoundIcon />}
                 content="Active Controller"
@@ -87,7 +88,7 @@ const BrokersList: React.FC = () => {
               />
             )}
           </S.RowCell>
-        ),
+        )},
       },
       {
         header: 'Disk usage',


### PR DESCRIPTION
<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)
When the broker index starts with anything other than 0 and onwards, the tick mark is not showing at the correct broker.
Example, our brokers starts with 1, for the first one and so on. The tick mark for active broker are always off by 1.

**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (please, describe, if necessary)
- [ ] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] New and existing unit tests pass locally with my changes

Check out [Contributing](https://github.com/provectus/kafka-ui/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/provectus/kafka-ui/blob/master/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**
![image](https://github.com/provectus/kafka-ui/assets/3225795/c59e5fb5-3d23-4c02-8c69-46703c7e565a)

