### PR TITLE
chore(kafka-ui-api): Upgrade base Docker image for Kafka UI API (Alpine 3.15 EOL)

### DIFF
--- a/kafka-ui-api/Dockerfile
+++ b/kafka-ui-api/Dockerfile
@@ -1,5 +1,5 @@
 #FROM azul/zulu-openjdk-alpine:17-jre-headless
-FROM azul/zulu-openjdk-alpine@sha256:a36679ac0d28cb835e2a8c00e1e0d95509c6c51c5081c7782b85edb1f37a771a
+FROM azul/zulu-openjdk-alpine@sha256:c4580a835aca618bfa82b614d1d5c771def44f302b8ce6d3f4750aa8fa968d3b
 
 RUN apk add --no-cache \
     # snappy codec


### PR DESCRIPTION
kafka-ui is running an **unsupported operating system Alpine 3.15.8**, which reached end of support 5 months ago, 2023 Nov 01. This leaves the system vulnerable to many security issues that can be exploited, as it does not receive security patches. For more information on this operating system, please follow [https://alpinelinux.org/releases/](https://alpinelinux.org/releases/)

**What changes did you make?**

Upgrade the base image which come with alpine 19.x


**How Has This Been Tested?** 
<!-- ignore-task-list-start -->
- [x] Manually (please, describe, if necessary)
<!-- ignore-task-list-end -->

The above Docker images have been tested manually by running the following commands:

```sh
docker run -it -p 8080:8080 --rm ghcr.io/adiii717/kafka-ui:v19
docker run -p 8080:8080 --rm ghcr.io/adiii717/kafka-ui:amd64
```



