### PR TITLE
Increase z-index of Select Dropdown element

### DIFF
--- a/kafka-ui-react-app/src/components/common/Select/Select.styled.ts
+++ b/kafka-ui-react-app/src/components/common/Select/Select.styled.ts
@@ -81,8 +81,8 @@ export const OptionList = styled.ul`
   line-height: 18px;
   color: ${({ theme }) => theme.select.color.normal};
   overflow-y: auto;
-  z-index: 10;
-  max-width: 300px;
+  z-index: 12;
+  max-width: 300px;s
   min-width: 100%;
   align-items: center;
   & div {


### PR DESCRIPTION
<!-- ignore-task-list-end -->
Increased `z-index` of select's dropdown element. Closes #4447. Tested manually.

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged



**A picture of a cute animal (not mandatory but encouraged)**
![image](https://github.com/provectus/kafka-ui/assets/22551739/bd559d8e-db1e-41a4-bdce-5fd9602739ce)
