### PR TITLE
update MSK-IAM-AUTH to support pod identity

### DIFF
--- a/kafka-ui-api/pom.xml
+++ b/kafka-ui-api/pom.xml
@@ -97,7 +97,7 @@
         <dependency>
             <groupId>software.amazon.msk</groupId>
             <artifactId>aws-msk-iam-auth</artifactId>
-            <version>1.1.7</version>
+            <version>2.2.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
update MSK-IAM-AUTH to support pod identity

The current AWS SDK throws this error when run under AWS's EKS Pod Identity

https://github.com/aws/aws-sdk-java/issues/3062



