### PR TITLE
kafka client version update 3.5.0 to 3.7.2

### DIFF
--- a/kafka-ui-contract/src/main/resources/swagger/kafka-ui-api.yaml
+++ b/kafka-ui-contract/src/main/resources/swagger/kafka-ui-api.yaml
@@ -3559,6 +3559,7 @@ components:
         - DYNAMIC_DEFAULT_BROKER_CONFIG
         - STATIC_BROKER_CONFIG
         - DEFAULT_CONFIG
+        - DYNAMIC_CLIENT_METRICS_CONFIG
         - UNKNOWN
 
     ConfigSynonym:

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <protobuf-java.version>3.23.3</protobuf-java.version>
         <scala-lang.library.version>2.13.9</scala-lang.library.version>
         <snakeyaml.version>2.0</snakeyaml.version>
-        <spring-boot.version>3.1.3</spring-boot.version>
+        <spring-boot.version>3.4.5</spring-boot.version>
         <kafka-ui-serde-api.version>1.0.0</kafka-ui-serde-api.version>
         <odd-oddrn-generator.version>0.1.17</odd-oddrn-generator.version>
         <odd-oddrn-client.version>0.1.26</odd-oddrn-client.version>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <datasketches-java.version>3.1.0</datasketches-java.version>
         <groovy.version>3.0.13</groovy.version>
         <jackson.version>2.14.0</jackson.version>
-        <kafka-clients.version>3.5.0</kafka-clients.version>
+        <kafka-clients.version>3.7.2</kafka-clients.version>
         <org.mapstruct.version>1.5.5.Final</org.mapstruct.version>
         <org.projectlombok.version>1.18.24</org.projectlombok.version>
         <protobuf-java.version>3.23.3</protobuf-java.version>


### PR DESCRIPTION
# Kafka Client Upgrade

## Overview

This project includes an upgrade of the Apache Kafka client library from version **3.5.0** to **3.7.2**. The previous version contained known security vulnerabilities, and this update ensures improved security, stability, and compatibility with modern Kafka features.

## What Changed

- **Kafka client version updated:**
  - **Old version:** `3.5.0`
  - **New version:** `3.7.2`
- **Reason for update:** The `3.5.0` version has a known vulnerability. Upgrading eliminates the security risk and aligns with the latest Kafka release.

## Updated Configuration

In your `pom.xml` or dependency configuration file, update the Kafka client version as shown below:

```xml
<!-- Before -->
<kafka-clients.version>3.5.0</kafka-clients.version>

<!-- After -->
<kafka-clients.version>3.7.2</kafka-clients.version>