### PR TITLE
fix: Update Tomcat to 10.1.35 to address CVE-2025-24813

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,8 @@
         <scala-lang.library.version>2.13.9</scala-lang.library.version>
         <snakeyaml.version>2.0</snakeyaml.version>
         <spring-boot.version>3.1.3</spring-boot.version>
+        <!-- CVE-2025-24813 FIX: Override Tomcat version -->
+        <tomcat.version>10.1.35</tomcat.version>
         <kafka-ui-serde-api.version>1.0.0</kafka-ui-serde-api.version>
         <odd-oddrn-generator.version>0.1.17</odd-oddrn-generator.version>
         <odd-oddrn-client.version>0.1.26</odd-oddrn-client.version>


### PR DESCRIPTION
## Summary
This PR updates the embedded Tomcat version from 10.1.12 to 10.1.35 to fix CVE-2025-24813, a critical vulnerability that could lead to Remote Code Execution and/or Information disclosure.

## Details
- **CVE ID**: CVE-2025-24813
- **CVSS Score**: 9.8 (Critical)
- **Component**: tomcat-embed-el 10.1.12
- **Fixed Version**: 10.1.35

## Vulnerability Description
Path Equivalence vulnerability in Apache Tomcat's Default Servlet could allow:
- Remote Code Execution
- Information disclosure
- Malicious content injection

The vulnerability affects:
- Apache Tomcat 11.0.0-M1 through 11.0.2
- Apache Tomcat 10.1.0-M1 through 10.1.34
- Apache Tomcat 9.0.0.M1 through 9.0.98

## Changes
- Updated `pom.xml` to override Tomcat version to 10.1.35
- This ensures all Tomcat embedded dependencies use the patched version

## Testing
- Built the project successfully with the updated dependency
- The application compiles and packages without issues

## References
- [CVE-2025-24813 Details](https://nvd.nist.gov/vuln/detail/CVE-2025-24813)
- [Apache Tomcat Security](https://tomcat.apache.org/security.html)

🤖 Generated with [Claude Code](https://claude.ai/code)