### PR TITLE
BE: Feature - Add support for nested field masking in Kafka UI.

### DIFF
--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/config/ClustersProperties.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/config/ClustersProperties.java
@@ -126,7 +126,6 @@ public class ClustersProperties {
     String keystoreLocation;
     String keystorePassword;
   }
-
   @Data
   public static class Masking {
     Type type;
@@ -136,6 +135,7 @@ public class ClustersProperties {
     String replacement; //used when type=REPLACE
     String topicKeysPattern;
     String topicValuesPattern;
+    Boolean enableNestedPaths = false; // New field to enable nested path support
 
     public enum Type {
       REMOVE, MASK, REPLACE

--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/service/masking/policies/FieldsSelector.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/service/masking/policies/FieldsSelector.java
@@ -2,6 +2,7 @@ package com.provectus.kafka.ui.service.masking.policies;
 
 import com.provectus.kafka.ui.config.ClustersProperties;
 import com.provectus.kafka.ui.exception.ValidationException;
+import java.util.List;
 import java.util.regex.Pattern;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
@@ -12,17 +13,62 @@ interface FieldsSelector {
     if (StringUtils.hasText(property.getFieldsNamePattern()) && !CollectionUtils.isEmpty(property.getFields())) {
       throw new ValidationException("You can't provide both fieldNames & fieldsNamePattern for masking");
     }
+    
+    boolean nestedPathsEnabled = Boolean.TRUE.equals(property.getEnableNestedPaths());
+    
     if (StringUtils.hasText(property.getFieldsNamePattern())) {
       Pattern pattern = Pattern.compile(property.getFieldsNamePattern());
-      return f -> pattern.matcher(f).matches();
+      return new FieldsSelector() {
+        @Override
+        public boolean shouldBeMasked(String fieldName) {
+          return pattern.matcher(fieldName).matches();
+        }
+        
+        @Override
+        public boolean shouldBeMasked(List<String> fieldPath) {
+          if (!nestedPathsEnabled) {
+            return shouldBeMasked(fieldPath.get(fieldPath.size() - 1));
+          }
+          String path = String.join(".", fieldPath);
+          return pattern.matcher(path).matches();
+        }
+      };
     }
+    
     if (!CollectionUtils.isEmpty(property.getFields())) {
-      return f -> property.getFields().contains(f);
+      return new FieldsSelector() {
+        @Override
+        public boolean shouldBeMasked(String fieldName) {
+          return property.getFields().contains(fieldName);
+        }
+        
+        @Override
+        public boolean shouldBeMasked(List<String> fieldPath) {
+          if (!nestedPathsEnabled) {
+            return shouldBeMasked(fieldPath.get(fieldPath.size() - 1));
+          }
+          String path = String.join(".", fieldPath);
+          return property.getFields().contains(path);
+        }
+      };
     }
+    
     //no pattern, no field names - mean all fields should be masked
-    return fieldName -> true;
+    return new FieldsSelector() {
+      @Override
+      public boolean shouldBeMasked(String fieldName) {
+        return true;
+      }
+      
+      @Override
+      public boolean shouldBeMasked(List<String> fieldPath) {
+        return true;
+      }
+    };
   }
 
   boolean shouldBeMasked(String fieldName);
+  
+  boolean shouldBeMasked(List<String> fieldPath);
 
 }

--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/service/masking/policies/Mask.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/service/masking/policies/Mask.java
@@ -50,23 +50,35 @@ class Mask extends MaskingPolicy {
       return sb.toString();
     };
   }
-
   private JsonNode maskWithFieldsCheck(JsonNode node) {
+    return maskWithFieldsCheck(node, new java.util.ArrayList<>());
+  }
+
+  private JsonNode maskWithFieldsCheck(JsonNode node, java.util.List<String> path) {
     if (node.isObject()) {
       ObjectNode obj = ((ObjectNode) node).objectNode();
       node.fields().forEachRemaining(f -> {
         String fieldName = f.getKey();
         JsonNode fieldVal = f.getValue();
-        if (fieldShouldBeMasked(fieldName)) {
+        
+        java.util.List<String> currentPath = new java.util.ArrayList<>(path);
+        currentPath.add(fieldName);
+        
+        if (fieldShouldBeMasked(fieldName) || fieldShouldBeMasked(currentPath)) {
           obj.set(fieldName, maskNodeRecursively(fieldVal));
         } else {
-          obj.set(fieldName, maskWithFieldsCheck(fieldVal));
+          obj.set(fieldName, maskWithFieldsCheck(fieldVal, currentPath));
         }
       });
       return obj;
     } else if (node.isArray()) {
       ArrayNode arr = ((ArrayNode) node).arrayNode(node.size());
-      node.elements().forEachRemaining(e -> arr.add(maskWithFieldsCheck(e)));
+      int index = 0;
+      for (JsonNode element : node) {
+        java.util.List<String> currentPath = new java.util.ArrayList<>(path);
+        currentPath.add(String.valueOf(index++));
+        arr.add(maskWithFieldsCheck(element, currentPath));
+      }
       return arr;
     }
     return node;

--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/service/masking/policies/MaskingPolicy.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/service/masking/policies/MaskingPolicy.java
@@ -2,6 +2,7 @@ package com.provectus.kafka.ui.service.masking.policies;
 
 import com.fasterxml.jackson.databind.node.ContainerNode;
 import com.provectus.kafka.ui.config.ClustersProperties;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -32,6 +33,10 @@ public abstract class MaskingPolicy {
 
   protected boolean fieldShouldBeMasked(String fieldName) {
     return fieldsSelector.shouldBeMasked(fieldName);
+  }
+
+  protected boolean fieldShouldBeMasked(List<String> fieldPath) {
+    return fieldsSelector.shouldBeMasked(fieldPath);
   }
 
   public abstract ContainerNode<?> applyToJsonContainer(ContainerNode<?> node);

--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/service/masking/policies/Remove.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/service/masking/policies/Remove.java
@@ -21,21 +21,33 @@ class Remove extends MaskingPolicy {
   public ContainerNode<?> applyToJsonContainer(ContainerNode<?> node) {
     return (ContainerNode<?>) removeFields(node);
   }
-
   private JsonNode removeFields(JsonNode node) {
+    return removeFields(node, new java.util.ArrayList<>());
+  }
+
+  private JsonNode removeFields(JsonNode node, java.util.List<String> path) {
     if (node.isObject()) {
       ObjectNode obj = ((ObjectNode) node).objectNode();
       node.fields().forEachRemaining(f -> {
         String fieldName = f.getKey();
         JsonNode fieldVal = f.getValue();
-        if (!fieldShouldBeMasked(fieldName)) {
-          obj.set(fieldName, removeFields(fieldVal));
+        
+        java.util.List<String> currentPath = new java.util.ArrayList<>(path);
+        currentPath.add(fieldName);
+        
+        if (!fieldShouldBeMasked(fieldName) && !fieldShouldBeMasked(currentPath)) {
+          obj.set(fieldName, removeFields(fieldVal, currentPath));
         }
       });
       return obj;
     } else if (node.isArray()) {
       var arr = ((ArrayNode) node).arrayNode(node.size());
-      node.elements().forEachRemaining(e -> arr.add(removeFields(e)));
+      int index = 0;
+      for (JsonNode element : node) {
+        java.util.List<String> currentPath = new java.util.ArrayList<>(path);
+        currentPath.add(String.valueOf(index++));
+        arr.add(removeFields(element, currentPath));
+      }
       return arr;
     }
     return node;

--- a/kafka-ui-api/src/main/java/com/provectus/kafka/ui/service/masking/policies/Replace.java
+++ b/kafka-ui-api/src/main/java/com/provectus/kafka/ui/service/masking/policies/Replace.java
@@ -27,23 +27,35 @@ class Replace extends MaskingPolicy {
   public ContainerNode<?> applyToJsonContainer(ContainerNode<?> node) {
     return (ContainerNode<?>) replaceWithFieldsCheck(node);
   }
-
   private JsonNode replaceWithFieldsCheck(JsonNode node) {
+    return replaceWithFieldsCheck(node, new java.util.ArrayList<>());
+  }
+
+  private JsonNode replaceWithFieldsCheck(JsonNode node, java.util.List<String> path) {
     if (node.isObject()) {
       ObjectNode obj = ((ObjectNode) node).objectNode();
       node.fields().forEachRemaining(f -> {
         String fieldName = f.getKey();
         JsonNode fieldVal = f.getValue();
-        if (fieldShouldBeMasked(fieldName)) {
+        
+        java.util.List<String> currentPath = new java.util.ArrayList<>(path);
+        currentPath.add(fieldName);
+        
+        if (fieldShouldBeMasked(fieldName) || fieldShouldBeMasked(currentPath)) {
           obj.set(fieldName, replaceRecursive(fieldVal));
         } else {
-          obj.set(fieldName, replaceWithFieldsCheck(fieldVal));
+          obj.set(fieldName, replaceWithFieldsCheck(fieldVal, currentPath));
         }
       });
       return obj;
     } else if (node.isArray()) {
       ArrayNode arr = ((ArrayNode) node).arrayNode(node.size());
-      node.elements().forEachRemaining(e -> arr.add(replaceWithFieldsCheck(e)));
+      int index = 0;
+      for (JsonNode element : node) {
+        java.util.List<String> currentPath = new java.util.ArrayList<>(path);
+        currentPath.add(String.valueOf(index++));
+        arr.add(replaceWithFieldsCheck(element, currentPath));
+      }
       return arr;
     }
     // if it is not an object or array - we have nothing to replace here

--- a/kafka-ui-api/src/test/java/com/provectus/kafka/ui/service/masking/policies/FieldsSelectorTest.java
+++ b/kafka-ui-api/src/test/java/com/provectus/kafka/ui/service/masking/policies/FieldsSelectorTest.java
@@ -50,4 +50,65 @@ class FieldsSelectorTest {
         .isInstanceOf(ValidationException.class);
   }
 
+  @Test
+  void selectsNestedFieldsWhenEnabledWithFieldNames() {
+    var properties = new ClustersProperties.Masking();
+    properties.setFields(List.of("user.email", "user.address.street"));
+    properties.setEnableNestedPaths(true);
+
+    var selector = FieldsSelector.create(properties);
+    
+    // Test single field names (backward compatibility)
+    assertThat(selector.shouldBeMasked("email")).isFalse();
+    assertThat(selector.shouldBeMasked("street")).isFalse();
+    
+    // Test nested paths
+    assertThat(selector.shouldBeMasked(List.of("user", "email"))).isTrue();
+    assertThat(selector.shouldBeMasked(List.of("user", "address", "street"))).isTrue();
+    assertThat(selector.shouldBeMasked(List.of("user", "name"))).isFalse();
+    assertThat(selector.shouldBeMasked(List.of("other", "email"))).isFalse();
+  }
+
+  @Test
+  void selectsNestedFieldsWhenEnabledWithPattern() {
+    var properties = new ClustersProperties.Masking();
+    properties.setFieldsNamePattern("user\\..*|.*\\.secret");
+    properties.setEnableNestedPaths(true);
+
+    var selector = FieldsSelector.create(properties);
+    
+    // Test nested paths with pattern
+    assertThat(selector.shouldBeMasked(List.of("user", "email"))).isTrue();
+    assertThat(selector.shouldBeMasked(List.of("user", "address", "street"))).isTrue();
+    assertThat(selector.shouldBeMasked(List.of("config", "secret"))).isTrue();
+    assertThat(selector.shouldBeMasked(List.of("other", "public"))).isFalse();
+  }
+
+  @Test
+  void fallsBackToFieldNameWhenNestedPathsDisabled() {
+    var properties = new ClustersProperties.Masking();
+    properties.setFields(List.of("user.email", "street"));
+    properties.setEnableNestedPaths(false);
+
+    var selector = FieldsSelector.create(properties);
+    
+    // Should only match the last part of the path when nested paths are disabled
+    assertThat(selector.shouldBeMasked(List.of("user", "email"))).isFalse(); // Only matches "email", not "user.email"
+    assertThat(selector.shouldBeMasked(List.of("address", "street"))).isTrue(); // Matches "street"
+    assertThat(selector.shouldBeMasked("street")).isTrue(); // Direct field name matching still works
+  }
+
+  @Test
+  void defaultNestedPathsBehaviorIsFalse() {
+    var properties = new ClustersProperties.Masking();
+    properties.setFields(List.of("user.email"));
+    // enableNestedPaths not set, should default to false
+
+    var selector = FieldsSelector.create(properties);
+    
+    // Should behave as if nested paths are disabled
+    assertThat(selector.shouldBeMasked(List.of("user", "email"))).isFalse();
+    assertThat(selector.shouldBeMasked("email")).isFalse();
+  }
+
 }

--- a/kafka-ui-api/src/test/java/com/provectus/kafka/ui/service/masking/policies/NestedFieldsMaskingTest.java
+++ b/kafka-ui-api/src/test/java/com/provectus/kafka/ui/service/masking/policies/NestedFieldsMaskingTest.java
@@ -1,0 +1,234 @@
+package com.provectus.kafka.ui.service.masking.policies;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.node.ContainerNode;
+import com.provectus.kafka.ui.config.ClustersProperties;
+import java.util.List;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+
+class NestedFieldsMaskingTest {
+
+  @Test
+  @SneakyThrows
+  void testNestedFieldMaskingWithReplace() {
+    var properties = new ClustersProperties.Masking();
+    properties.setType(ClustersProperties.Masking.Type.REPLACE);
+    properties.setReplacement("***MASKED***");
+    properties.setFields(List.of("user.address.street", "user.email"));
+    properties.setEnableNestedPaths(true);
+
+    var policy = MaskingPolicy.create(properties);
+    
+    String inputJson = """
+        {
+          "user": {
+            "name": "John Doe",
+            "email": "john@example.com",
+            "address": {
+              "street": "123 Main St",
+              "city": "Anytown",
+              "zipcode": "12345"
+            }
+          },
+          "order": {
+            "id": "ORD-001",
+            "total": 99.99
+          }
+        }
+        """;
+
+    String expectedJson = """
+        {
+          "user": {
+            "name": "John Doe",
+            "email": "***MASKED***",
+            "address": {
+              "street": "***MASKED***",
+              "city": "Anytown",
+              "zipcode": "12345"
+            }
+          },
+          "order": {
+            "id": "ORD-001",
+            "total": 99.99
+          }
+        }
+        """;
+
+    JsonMapper mapper = new JsonMapper();
+    ContainerNode<?> input = (ContainerNode<?>) mapper.readTree(inputJson);
+    ContainerNode<?> expected = (ContainerNode<?>) mapper.readTree(expectedJson);
+    
+    ContainerNode<?> result = policy.applyToJsonContainer(input);
+    assertThat(result).isEqualTo(expected);
+  }
+
+  @Test
+  @SneakyThrows
+  void testNestedFieldMaskingWithRemove() {
+    var properties = new ClustersProperties.Masking();
+    properties.setType(ClustersProperties.Masking.Type.REMOVE);
+    properties.setFields(List.of("user.sensitiveData", "metadata.internal"));
+    properties.setEnableNestedPaths(true);
+
+    var policy = MaskingPolicy.create(properties);
+    
+    String inputJson = """
+        {
+          "user": {
+            "name": "John Doe",
+            "sensitiveData": {
+              "ssn": "123-45-6789",
+              "creditCard": "4111-1111-1111-1111"
+            },
+            "publicInfo": "Available"
+          },
+          "metadata": {
+            "timestamp": "2023-01-01",
+            "internal": {
+              "secret": "top-secret",
+              "debug": "trace-info"
+            }
+          }
+        }
+        """;
+
+    String expectedJson = """
+        {
+          "user": {
+            "name": "John Doe",
+            "publicInfo": "Available"
+          },
+          "metadata": {
+            "timestamp": "2023-01-01"
+          }
+        }
+        """;
+
+    JsonMapper mapper = new JsonMapper();
+    ContainerNode<?> input = (ContainerNode<?>) mapper.readTree(inputJson);
+    ContainerNode<?> expected = (ContainerNode<?>) mapper.readTree(expectedJson);
+    
+    ContainerNode<?> result = policy.applyToJsonContainer(input);
+    assertThat(result).isEqualTo(expected);
+  }
+
+  @Test
+  @SneakyThrows
+  void testNestedFieldMaskingWithPattern() {
+    var properties = new ClustersProperties.Masking();
+    properties.setType(ClustersProperties.Masking.Type.MASK);
+    properties.setMaskingCharsReplacement(List.of("X", "x", "n", "-"));
+    properties.setFieldsNamePattern(".*\\.secret.*");
+    properties.setEnableNestedPaths(true);
+
+    var policy = MaskingPolicy.create(properties);
+    
+    String inputJson = """
+        {
+          "config": {
+            "publicSetting": "visible",
+            "secretKey": "my-secret-key",
+            "database": {
+              "host": "localhost",
+              "secretPassword": "very-secret-password"
+            }
+          }
+        }
+        """;
+
+    JsonMapper mapper = new JsonMapper();
+    ContainerNode<?> input = (ContainerNode<?>) mapper.readTree(inputJson);
+    
+    ContainerNode<?> result = policy.applyToJsonContainer(input);
+    
+    // Verify that nested secret fields are masked
+    JsonNode configNode = result.get("config");
+    assertThat(configNode.get("publicSetting").asText()).isEqualTo("visible");
+    assertThat(configNode.get("secretKey").asText()).isEqualTo("xx-xxxxxx-xxx"); // masked
+    
+    JsonNode databaseNode = configNode.get("database");
+    assertThat(databaseNode.get("host").asText()).isEqualTo("localhost");
+    assertThat(databaseNode.get("secretPassword").asText()).isEqualTo("xxxx-xxxxxx-xxxxxxxx"); // masked
+  }
+
+  @Test
+  @SneakyThrows
+  void testBackwardCompatibilityWithoutNestedPaths() {
+    var properties = new ClustersProperties.Masking();
+    properties.setType(ClustersProperties.Masking.Type.REPLACE);
+    properties.setReplacement("***MASKED***");
+    properties.setFields(List.of("email")); // Only top-level field names
+    properties.setEnableNestedPaths(false); // Explicitly disabled
+
+    var policy = MaskingPolicy.create(properties);
+    
+    String inputJson = """
+        {
+          "email": "john@example.com",
+          "user": {
+            "email": "nested@example.com"
+          }
+        }
+        """;
+
+    String expectedJson = """
+        {
+          "email": "***MASKED***",
+          "user": {
+            "email": "***MASKED***"
+          }
+        }
+        """;
+
+    JsonMapper mapper = new JsonMapper();
+    ContainerNode<?> input = (ContainerNode<?>) mapper.readTree(inputJson);
+    ContainerNode<?> expected = (ContainerNode<?>) mapper.readTree(expectedJson);
+    
+    ContainerNode<?> result = policy.applyToJsonContainer(input);
+    assertThat(result).isEqualTo(expected);
+  }
+
+  @Test
+  @SneakyThrows
+  void testArrayElementsWithNestedPaths() {
+    var properties = new ClustersProperties.Masking();
+    properties.setType(ClustersProperties.Masking.Type.REPLACE);
+    properties.setReplacement("***MASKED***");
+    properties.setFields(List.of("users.email"));
+    properties.setEnableNestedPaths(true);
+
+    var policy = MaskingPolicy.create(properties);
+    
+    String inputJson = """
+        {
+          "users": [
+            {
+              "name": "John",
+              "email": "john@example.com"
+            },
+            {
+              "name": "Jane",
+              "email": "jane@example.com"
+            }
+          ]
+        }
+        """;
+
+    JsonMapper mapper = new JsonMapper();
+    ContainerNode<?> input = (ContainerNode<?>) mapper.readTree(inputJson);
+    
+    ContainerNode<?> result = policy.applyToJsonContainer(input);
+    
+    // Since we're using array indices in the path, this should only mask exact path matches
+    // In this case, users.email doesn't match users.0.email or users.1.email
+    // So emails should remain unmasked unless we specify the full path with indices
+    JsonNode usersNode = result.get("users");
+    assertThat(usersNode.get(0).get("email").asText()).isEqualTo("john@example.com");
+    assertThat(usersNode.get(1).get("email").asText()).isEqualTo("jane@example.com");
+  }
+}


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)

<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)
Problem Solved (Issue reported: https://github.com/provectus/kafka-ui/issues/4361)
Previously, the masking feature only supported top-level field names. Users couldn't mask specific nested fields within complex JSON structures, leading to either over-masking (masking entire objects) or under-masking (missing sensitive nested data).

Features Added
1. Nested Field Path Support
Dot Notation: Support for paths like user.email and etc
Pattern Matching: Regex patterns now work with full field paths (e.g., .*\.secret.*)
Array Support: Handles arrays with indexed paths (e.g., users.0.email)
2. New Configuration Option
3. Backward Compatibility
Default Behavior: enableNestedPaths defaults to false
Existing Configs: All current masking configurations continue to work unchanged
No Breaking Changes: API endpoints and data structures remain the same

**Is there anything you'd like reviewers to focus on?**


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [ ] Manually (please, describe, if necessary)
- [x] Unit checks
- [x] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/provectus/kafka-ui/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/provectus/kafka-ui/blob/master/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**
