### PR TITLE
[RBAC] Deny access to user with no permissions #2946

### DIFF
--- a/kafka-ui-react-app/src/components/PageContainer/PageContainer.tsx
+++ b/kafka-ui-react-app/src/components/PageContainer/PageContainer.tsx
@@ -4,7 +4,7 @@ import NavBar from 'components/NavBar/NavBar';
 import * as S from 'components/PageContainer/PageContainer.styled';
 import Nav from 'components/Nav/Nav';
 import useBoolean from 'lib/hooks/useBoolean';
-import { clusterNewConfigPath } from 'lib/paths';
+import { accessErrorPage, clusterNewConfigPath } from 'lib/paths';
 import { GlobalSettingsContext } from 'components/contexts/GlobalSettingsContext';
 import { useClusters } from 'lib/hooks/api/clusters';
 import { ResourceType } from 'generated-sources';
@@ -33,12 +33,24 @@ const PageContainer: React.FC<PropsWithChildren<unknown>> = ({ children }) => {
     );
   }, [authInfo]);
 
+  const hasNoPermissions = useMemo(() => {    // If RBAC is not enabled, we assume the user has permissions, so we return false for "has no permissions".
+  if (!authInfo?.rbacEnabled) return false;
+  if (authInfo?.userInfo === undefined) return false;
+  return authInfo.userInfo.permissions.length === 0;
+  }, [authInfo]);
+
   useEffect(() => {
     if (!appInfo.hasDynamicConfig) return;
     if (clusters?.data?.length !== 0) return;
     if (!hasApplicationPermissions) return;
     navigate(clusterNewConfigPath);
   }, [clusters?.data, appInfo.hasDynamicConfig]);
+
+  useEffect(() => {
+  if (hasNoPermissions) {
+    navigate(accessErrorPage);
+  }
+}, [hasNoPermissions, navigate]);
 
   return (
     <>


### PR DESCRIPTION
When RBAC is enabled and a user has no permissions assigned,
they are now redirected to the 403 Access Denied page instead
of seeing a blank dashboard.

Fixes #2946

<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)
<!-- ignore-task-list-end -->

**What changes did you make?**

Added a `hasNoPermissions` computed value in `PageContainer.tsx`
that checks if RBAC is enabled and the authenticated user has zero
permissions. If true, the user is redirected to the existing `/403`
Access Denied page instead of seeing a blank dashboard.

**Is there anything you'd like reviewers to focus on?**

Whether the redirect logic placement in PageContainer is appropriate,
and if the existing 403 page message "Access is Denied" is sufficient
or should be more specific like "No permissions assigned to your
account. Contact your administrator."

**How Has This Been Tested?**

<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (please, describe, if necessary)
- [ ] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

Mocked `useGetUserInfo` to return `rbacEnabled: true` with an empty
permissions array and confirmed redirect to `/403` page. Reverted
mock and confirmed normal flow is unaffected.

**Checklist**

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

![cute animal](https://upload.wikimedia.org/wikipedia/commons/thumb/3/3a/Cat03.jpg/1200px-Cat03.jpg)