### PR TITLE
fix: handle null values in broker config search filter

### DIFF
--- a/kafka-ui-react-app/src/components/Brokers/Broker/Configs/Configs.tsx
+++ b/kafka-ui-react-app/src/components/Brokers/Broker/Configs/Configs.tsx
@@ -38,12 +38,12 @@ const Configs: React.FC = () => {
         const nameMatch = item.name
           .toLocaleLowerCase()
           .includes(keyword.toLocaleLowerCase());
-        return nameMatch
-          ? true
-          : item.value &&
-              item.value
-                .toLocaleLowerCase()
-                .includes(keyword.toLocaleLowerCase()); // try to match the keyword on any of the item.value elements when nameMatch fails but item.value exists
+        return (
+          nameMatch ||
+          String(item.value)
+            .toLocaleLowerCase()
+            .includes(keyword.toLocaleLowerCase())
+        );
       })
       .sort((a, b) => {
         if (a.source === b.source) return 0;

--- a/kafka-ui-react-app/src/components/Brokers/Broker/Configs/__test__/Configs.spec.tsx
+++ b/kafka-ui-react-app/src/components/Brokers/Broker/Configs/__test__/Configs.spec.tsx
@@ -40,6 +40,32 @@ describe('Configs', () => {
     );
   });
 
+  it('filters by value including null values', async () => {
+    const configsWithNull = [
+      ...brokerConfigPayload,
+      {
+        name: 'some.config.with.null.value',
+        value: null,
+        source: 'DEFAULT_CONFIG',
+        isSensitive: false,
+        isReadOnly: false,
+        synonyms: [],
+      },
+    ];
+    (useBrokerConfig as jest.Mock).mockImplementation(() => ({
+      data: configsWithNull,
+    }));
+    renderComponent();
+
+    const searchInput = screen.getByPlaceholderText('Search by Key or Value');
+    await userEvent.type(searchInput, 'null');
+
+    const rows = screen.getAllByRole('row');
+    // header row + the row with null value should be visible
+    expect(rows.length).toBeGreaterThan(1);
+    expect(screen.getByText('some.config.with.null.value')).toBeInTheDocument();
+  });
+
   it('updates textbox value', async () => {
     await userEvent.click(screen.getAllByLabelText('editAction')[0]);
 

--- a/kafka-ui-react-app/src/components/Brokers/Broker/Configs/__test__/Configs.spec.tsx
+++ b/kafka-ui-react-app/src/components/Brokers/Broker/Configs/__test__/Configs.spec.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { screen } from '@testing-library/dom';
+import { cleanup } from '@testing-library/react';
 import { render, WithRoute } from 'lib/testHelpers';
 import { clusterBrokerConfigsPath } from 'lib/paths';
 import { useBrokerConfig } from 'lib/hooks/api/brokers';
@@ -13,6 +14,10 @@ const brokerId = 'Broker_Id';
 jest.mock('lib/hooks/api/brokers', () => ({
   useBrokerConfig: jest.fn(),
   useUpdateBrokerConfigByName: jest.fn(),
+}));
+
+jest.mock('use-debounce', () => ({
+  useDebouncedCallback: (fn: (e: Event) => void) => fn,
 }));
 
 describe('Configs', () => {
@@ -55,15 +60,14 @@ describe('Configs', () => {
     (useBrokerConfig as jest.Mock).mockImplementation(() => ({
       data: configsWithNull,
     }));
+    cleanup();
     renderComponent();
 
     const searchInput = screen.getByPlaceholderText('Search by Key or Value');
     await userEvent.type(searchInput, 'null');
 
-    const rows = screen.getAllByRole('row');
-    // header row + the row with null value should be visible
-    expect(rows.length).toBeGreaterThan(1);
     expect(screen.getByText('some.config.with.null.value')).toBeInTheDocument();
+    expect(screen.queryByText('compression.type')).not.toBeInTheDocument();
   });
 
   it('updates textbox value', async () => {


### PR DESCRIPTION
## Summary

Fixes #4180

When searching in **Brokers > Configs**, the Value column search fails to return any results for configs whose `value` is `null`. Searching for `"null"` returns zero rows despite those rows being visible in the table.

### Root Cause

The filter used a short-circuit `&&` guard:
```ts
: item.value &&
    item.value.toLocaleLowerCase().includes(keyword.toLocaleLowerCase())
```
When `item.value` is `null`, JavaScript evaluates `null && ...` to `null` (falsy), so the item is excluded from results entirely — regardless of what the user typed.

### Fix

Replace the null-guarded chain with `String(item.value)`, which converts `null` → `"null"` (matching what the UI renders) and `""` → `""`:

```ts
return (
  nameMatch ||
  String(item.value)
    .toLocaleLowerCase()
    .includes(keyword.toLocaleLowerCase())
);
```

### Test Added

A new unit test in `Configs.spec.tsx` mocks a config with `value: null`, types `"null"` into the search box, and asserts the row with that config name is visible in the DOM.

## Test Plan

- [ ] Run `yarn test --testPathPattern="Configs.spec"` — all tests pass including the new one
- [ ] Spin up kafka-ui locally, navigate to Brokers > select a broker > Configs tab
- [ ] Search for `"null"` — rows with null values should now appear


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the config table search matching logic, including more reliable handling of empty, missing, or null config values.
* **Tests**
  * Added UI test coverage to verify that searching by key/value correctly displays rows whose values are null.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->